### PR TITLE
Init by go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/upsidr/importer
+
+go 1.15


### PR DESCRIPTION
Init by GoModule.

Considering that it would be public in the future, the module path is set on `github.com`.
If we have a problem with this after the actual development starts, we can probably avoid that by setting [replace statement](https://thewebivore.com/using-replace-in-go-mod-to-point-to-your-local-module/).