### PR TITLE
Support generate

### DIFF
--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -39,7 +39,7 @@ func executeGenerateCLI(cmd *cli.Context) error {
 	args := cmd.Args()
 	// TODO: add some util func to hande all common error cases
 	if args.Len() < 1 {
-		return errors.New("error: incorrect argument, you can only pass in 1 argument")
+		return errors.New("error: incorrect argument, you need to pass in an argument")
 	}
 
 	arg := args.First()

--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -22,26 +22,36 @@ var (
 While ` + "`update`" + ` command is useful for managing file content in itself, ` + "`generate`" + ` can be used to create a separate template file.
 This approach allows the input file to be full of Importer markes without actual importing, and only used as the template to generate a new file.
 `,
+		Flags: []cli.Flag{
+			&cli.PathFlag{
+				Name:        "out",
+				Aliases:     []string{"o"},
+				Usage:       "write to `FILE`",
+				Destination: &generateTargetFile,
+			},
+		},
 		Action: executeGenerateCLI,
 	}
+	generateTargetFile string
 )
 
 func executeGenerateCLI(cmd *cli.Context) error {
 	args := cmd.Args()
 	// TODO: add some util func to hande all common error cases
-	if args.Len() != 1 {
+	if args.Len() < 1 {
 		return errors.New("error: incorrect argument, you can only pass in 1 argument")
 	}
 
 	arg := args.First()
-	if err := generate(arg); err != nil {
+	out := generateTargetFile
+	if err := generate(arg, out); err != nil {
 		return fmt.Errorf("error: handling generate, %v", err)
 	}
 
 	return nil
 }
 
-func generate(fileName string) error {
+func generate(fileName string, targetFilepath string) error {
 	f, err := os.Open(fileName)
 	if err != nil {
 		return err
@@ -58,10 +68,9 @@ func generate(fileName string) error {
 		return err
 	}
 
-	err = file.ReplaceWithAfter()
-	if err != nil {
-		return err
+	if targetFilepath != "" {
+		return file.WriteAfterTo(targetFilepath)
 	}
 
-	return nil
+	return file.PrintAfter()
 }

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -126,7 +126,7 @@ func TestGenerateStdoutWithHelper(t *testing.T) {
 				return
 			}
 
-			stdout := fakeStdout.Read(t)
+			stdout := fakeStdout.ReadAllAndClose(t)
 
 			if *updateGolden {
 				golden.UpdateFile(t, tc.wantFile, stdout)

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -58,6 +58,8 @@ func TestGenerateStdout(t *testing.T) {
 				if !strings.Contains(err.Error(), tc.wantErrString) {
 					t.Fatalf("error with generate, %v", err)
 				}
+				w.Close()
+				os.Stdout = origStdout
 				return
 			}
 

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/upsidr/importer/internal/testingutil/golden"
+)
+
+func TestUpdate(t *testing.T) {
+	cases := map[string]struct {
+		// Input
+		inputFile string
+
+		// Output
+		wantFile string
+	}{
+		"markdown": {
+			inputFile: "../../testdata/simple-before.md",
+			wantFile:  "../../testdata/simple-after.md",
+		},
+		"markdown long input": {
+			inputFile: "../../testdata/long-input-purged.md",
+			wantFile:  "../../testdata/long-input-after.md",
+		},
+		"markdown with exporter": {
+			inputFile: "../../testdata/using-exporter-before.md",
+			wantFile:  "../../testdata/using-exporter-after.md",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			copiedFile, remove := golden.CopyTemp(t, tc.inputFile)
+			defer remove()
+
+			err := update(copiedFile)
+			if err != nil {
+				t.Fatalf("error with generate, %v", err)
+			}
+
+			if *updateGolden {
+				processed := golden.File(t, copiedFile)
+				golden.UpdateFile(t, tc.wantFile, processed)
+			}
+
+			got := golden.FileAsString(t, copiedFile)
+			want := golden.FileAsString(t, tc.wantFile)
+
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("result didn't match (-want / +got)\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/file/print.go
+++ b/internal/file/print.go
@@ -1,0 +1,15 @@
+package file
+
+import (
+	"fmt"
+)
+
+func (f *File) PrintAfter() error {
+	fmt.Printf("%s", f.ContentAfter)
+	return nil
+}
+
+func (f *File) PrintPurged() error {
+	fmt.Printf("%s", f.ContentPurged)
+	return nil
+}

--- a/internal/file/process.go
+++ b/internal/file/process.go
@@ -9,6 +9,8 @@ import (
 )
 
 // ProcessAnnotations reads annotations and generates ContentAfter.
+//
+// TODO: possibly remove error return, as it currently never returns any error.
 func (f *File) ProcessAnnotations() error {
 	result := []byte{}
 	br := byte('\n')

--- a/internal/file/write.go
+++ b/internal/file/write.go
@@ -1,0 +1,26 @@
+package file
+
+import "os"
+
+// WriteAfterTo takes the processed content and copies into provided filepath.
+//
+// TODO: Ensure file mode is kept, or clarify in the comment.
+func (f *File) WriteAfterTo(filepath string) error {
+	file, err := os.CreateTemp("/tmp/", "importer_replace_*")
+	if err != nil {
+		return err // TODO: test coverage
+	}
+	defer file.Close()
+
+	_, err = file.Write(f.ContentAfter)
+	if err != nil {
+		return err // TODO: test coverage
+	}
+
+	err = os.Rename(file.Name(), filepath)
+	if err != nil {
+		return err // TODO: test coverage
+	}
+
+	return nil
+}

--- a/internal/testingutil/stdout/stdout.go
+++ b/internal/testingutil/stdout/stdout.go
@@ -1,0 +1,60 @@
+package stdout
+
+import (
+	"io"
+	"os"
+	"testing"
+)
+
+type Stdout struct {
+	origStdout *os.File
+
+	fakeStdin  *os.File
+	fakeStdout *os.File
+
+	isClosed bool
+}
+
+func New(t testing.TB) *Stdout {
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	os.Stdout = w
+
+	return &Stdout{
+		origStdout: origStdout,
+		fakeStdin:  r,
+		fakeStdout: w,
+	}
+}
+
+// Read reads from Stdout. After reading once, Stdout setup will be closed and
+// thus cannot be reused.
+func (s *Stdout) Read(t testing.TB) []byte {
+	if s.isClosed {
+		t.Fatalf("stdout is already closed")
+	}
+	s.fakeStdout.Close()
+	os.Stdout = s.origStdout
+
+	stdoutResult, err := io.ReadAll(s.fakeStdin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.fakeStdin.Close()
+
+	s.isClosed = true
+	return stdoutResult
+}
+
+// Close closes all open files for Stdout testing, and put back the original
+// stdout in place.
+func (s *Stdout) Close() {
+	s.fakeStdout.Close()
+	s.fakeStdin.Close()
+	os.Stdout = s.origStdout
+	s.isClosed = true
+}

--- a/internal/testingutil/stdout/stdout.go
+++ b/internal/testingutil/stdout/stdout.go
@@ -6,16 +6,21 @@ import (
 	"testing"
 )
 
+// Stdout holds fake Stdout, which can be used to replace normal Stdout for
+// testing. Use New() function to create this struct.
 type Stdout struct {
-	origStdout *os.File
-
-	fakeStdin  *os.File
-	fakeStdout *os.File
+	origStdout   *os.File
+	stdoutWriter *os.File
+	stdoutReader *os.File
 
 	isClosed bool
 }
 
+// New sets up os.File for os.Stdout, and ensures any stdout is captured.
+// Captured output can be read by Stdout.Read(testing.TB) function.
 func New(t testing.TB) *Stdout {
+	t.Helper()
+
 	origStdout := os.Stdout
 	r, w, err := os.Pipe()
 	if err != nil {
@@ -25,26 +30,29 @@ func New(t testing.TB) *Stdout {
 	os.Stdout = w
 
 	return &Stdout{
-		origStdout: origStdout,
-		fakeStdin:  r,
-		fakeStdout: w,
+		origStdout:   origStdout,
+		stdoutWriter: w,
+		stdoutReader: r,
 	}
 }
 
-// Read reads from Stdout. After reading once, Stdout setup will be closed and
-// thus cannot be reused.
-func (s *Stdout) Read(t testing.TB) []byte {
+// ReadAllAndClose reads from Stdout. After reading once, Stdout setup will be
+// closed and thus cannot be reused.
+func (s *Stdout) ReadAllAndClose(t testing.TB) []byte {
+	t.Helper()
+
 	if s.isClosed {
 		t.Fatalf("stdout is already closed")
 	}
-	s.fakeStdout.Close()
+
+	s.stdoutWriter.Close()
 	os.Stdout = s.origStdout
 
-	stdoutResult, err := io.ReadAll(s.fakeStdin)
+	stdoutResult, err := io.ReadAll(s.stdoutReader)
 	if err != nil {
 		t.Fatal(err)
 	}
-	s.fakeStdin.Close()
+	s.stdoutReader.Close()
 
 	s.isClosed = true
 	return stdoutResult
@@ -53,8 +61,9 @@ func (s *Stdout) Read(t testing.TB) []byte {
 // Close closes all open files for Stdout testing, and put back the original
 // stdout in place.
 func (s *Stdout) Close() {
-	s.fakeStdout.Close()
-	s.fakeStdin.Close()
+	s.stdoutWriter.Close()
+	s.stdoutReader.Close()
 	os.Stdout = s.origStdout
+
 	s.isClosed = true
 }


### PR DESCRIPTION
Updates #17 

--

Added

- `generate` command to send output to stdout
- `generate` command to support `--out FILENAME` or `-o FILENAME` flag to write to the given file
- Add test cases for `generate` specific, and move the existing test cases to `update`
