### PR TITLE
Fix unbalanced indentation handling

### DIFF
--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -37,6 +37,10 @@ func TestGenerateStdout(t *testing.T) {
 			inputFile: "../../testdata/yaml/align-with-exporter-before.yaml",
 			wantFile:  "../../testdata/yaml/align-with-exporter-updated.yaml",
 		},
+		"yaml with exporter and align, k8s": {
+			inputFile: "../../testdata/yaml/k8s-color-svc-before.yaml",
+			wantFile:  "../../testdata/yaml/k8s-color-svc-updated.yaml",
+		},
 		"error case: file not found": {
 			inputFile:     "does_not_exist",
 			wantErrString: "no such file",

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -163,6 +163,7 @@ func parse(markerRegex string, fileName string, input io.Reader) (*file.File, er
 				inNested = false
 				nestedUnder = ""
 				matchData.IsEndFound = true
+				continue
 			default:
 				panic("unknown marker condition") // Should not happen, but putting this for possible future changes
 			}

--- a/testdata/yaml/k8s-color-svc-before.yaml
+++ b/testdata/yaml/k8s-color-svc-before.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: color-svc-only-green
+  labels:
+    app.kubernetes.io/name: color-svc-only-green
+spec:
+  ports:
+    - name: http
+      port: 8800
+      targetPort: 8800
+  selector:
+    app.kubernetes.io/name: color-svc-only-green
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: color-svc-only-green
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: color-svc-only-green
+      app.kubernetes.io/version: v1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: color-svc-only-green
+        app.kubernetes.io/version: v1
+    spec:
+      serviceAccountName: color-svc
+      containers:
+        # == imptr: latest-color-svc / begin from: ./snippet-k8s-color-svc.yaml#[latest-svc] indent: align ==
+        - image: docker.io/rytswd/color-svc:latest
+          name: color-svc
+          command:
+            - color-svc
+          ports:
+            - containerPort: 8800
+          # == imptr: latest-color-svc / end ==
+
+          env:
+            # == imptr: color-svc-default-envs / begin from: ./snippet-k8s-color-svc.yaml#[basic-envs] indent: align ==
+            # == imptr: color-svc-default-envs / end ==
+            - name: DISABLE_RED
+              value: "true"
+            - name: DISABLE_GREEN
+              value: "false" # The same as default
+            - name: DISABLE_BLUE
+              value: "true"
+            - name: DISABLE_YELLOW
+              value: "true"
+
+          # == imptr: resource-footprint / begin from: ./snippet-k8s-resource.yaml#[min-resource] indent: align ==
+          data: |
+            this will be purged
+          # == imptr: resource-footprint / end ==

--- a/testdata/yaml/k8s-color-svc-purged.yaml
+++ b/testdata/yaml/k8s-color-svc-purged.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: color-svc-only-green
+  labels:
+    app.kubernetes.io/name: color-svc-only-green
+spec:
+  ports:
+    - name: http
+      port: 8800
+      targetPort: 8800
+  selector:
+    app.kubernetes.io/name: color-svc-only-green
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: color-svc-only-green
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: color-svc-only-green
+      app.kubernetes.io/version: v1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: color-svc-only-green
+        app.kubernetes.io/version: v1
+    spec:
+      serviceAccountName: color-svc
+      containers:
+        # == imptr: latest-color-svc / begin from: ./snippet-k8s-color-svc.yaml#[latest-svc] indent: align ==
+          # == imptr: latest-color-svc / end ==
+
+          env:
+            # == imptr: color-svc-default-envs / begin from: ./snippet-k8s-color-svc.yaml#[basic-envs] indent: align ==
+            # == imptr: color-svc-default-envs / end ==
+            - name: DISABLE_RED
+              value: "true"
+            - name: DISABLE_GREEN
+              value: "false" # The same as default
+            - name: DISABLE_BLUE
+              value: "true"
+            - name: DISABLE_YELLOW
+              value: "true"
+
+          # == imptr: resource-footprint / begin from: ./snippet-k8s-resource.yaml#[min-resource] indent: align ==
+          # == imptr: resource-footprint / end ==

--- a/testdata/yaml/k8s-color-svc-updated.yaml
+++ b/testdata/yaml/k8s-color-svc-updated.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: color-svc-only-green
+  labels:
+    app.kubernetes.io/name: color-svc-only-green
+spec:
+  ports:
+    - name: http
+      port: 8800
+      targetPort: 8800
+  selector:
+    app.kubernetes.io/name: color-svc-only-green
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: color-svc-only-green
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: color-svc-only-green
+      app.kubernetes.io/version: v1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: color-svc-only-green
+        app.kubernetes.io/version: v1
+    spec:
+      serviceAccountName: color-svc
+      containers:
+        # == imptr: latest-color-svc / begin from: ./snippet-k8s-color-svc.yaml#[latest-svc] indent: align ==
+        - image: docker.io/rytswd/color-svc:latest
+          name: color-svc
+          command:
+            - color-svc
+          ports:
+            - containerPort: 8800
+          # == imptr: latest-color-svc / end ==
+
+          env:
+            # == imptr: color-svc-default-envs / begin from: ./snippet-k8s-color-svc.yaml#[basic-envs] indent: align ==
+            - name: ENABLE_DELAY
+              value: "true"
+            - name: DELAY_DURATION_MILLISECOND
+              value: "500"
+            - name: ENABLE_CORS
+              value: "true"
+            # == imptr: color-svc-default-envs / end ==
+            - name: DISABLE_RED
+              value: "true"
+            - name: DISABLE_GREEN
+              value: "false" # The same as default
+            - name: DISABLE_BLUE
+              value: "true"
+            - name: DISABLE_YELLOW
+              value: "true"
+
+          # == imptr: resource-footprint / begin from: ./snippet-k8s-resource.yaml#[min-resource] indent: align ==
+          resources:
+            requests:
+              cpu: 10m
+              memory: 10Mi
+            limits:
+              cpu: 30m
+              memory: 30Mi
+          # == imptr: resource-footprint / end ==

--- a/testdata/yaml/snippet-k8s-color-svc.yaml
+++ b/testdata/yaml/snippet-k8s-color-svc.yaml
@@ -1,0 +1,39 @@
+containers:
+  # == export: latest-svc / begin ==
+  - image: docker.io/rytswd/color-svc:latest
+    name: color-svc
+    command:
+      - color-svc
+    ports:
+      - containerPort: 8800
+  # == export: latest-svc / end ==
+
+  # == export: v0.1.0 / begin ==
+  - image: docker.io/rytswd/color-svc:0.1.0
+    name: color-svc
+    command:
+      - color-svc
+    ports:
+      - containerPort: 8800
+  # == export: v0.1.0 / end ==
+
+envs:
+  # == export: basic-envs / begin ==
+  - name: ENABLE_DELAY
+    value: "true"
+  - name: DELAY_DURATION_MILLISECOND
+    value: "500"
+  - name: ENABLE_CORS
+    value: "true"
+  # == export: basic-envs / end ==
+
+  # == export: disable-all-colours / begin ==
+  - name: DISABLE_RED
+    value: "true"
+  - name: DISABLE_GREEN
+    value: "true"
+  - name: DISABLE_BLUE
+    value: "true"
+  - name: DISABLE_YELLOW
+    value: "true"
+  # == export: enable-all-colours / end ==

--- a/testdata/yaml/snippet-k8s-resource.yaml
+++ b/testdata/yaml/snippet-k8s-resource.yaml
@@ -1,0 +1,10 @@
+minimal:
+  # == export: min-resource / begin ==
+  resources:
+    requests:
+      cpu: 10m
+      memory: 10Mi
+    limits:
+      cpu: 30m
+      memory: 30Mi
+  # == export: min-resource / end ==


### PR DESCRIPTION
Fixed

- Corrected indentation handling when Importer Marker indentation is unbalanced in YAML. This shouldn't be usually necessary, but sometimes YAML arrays would force unbalanced indent. With this fix, the Importer Marker indent is only taken from the `begin` marker.