### PR TITLE
Fix file mode handling

### DIFF
--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -38,6 +38,9 @@ func executeGenerate(cmd *cobra.Command, args []string) error {
 		return errors.New("incorrect argument, you need to pass in an argument")
 	}
 
+	// Suppress usage message after this point
+	cmd.SilenceUsage = true
+
 	arg := args[0]
 	out := generateTargetFile
 	if err := generate(arg, out); err != nil {

--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -33,14 +33,15 @@ func init() {
 
 func executeGenerate(cmd *cobra.Command, args []string) error {
 	// TODO: add some util func to hande all common error cases
+
 	if len(args) < 1 {
-		return errors.New("error: incorrect argument, you need to pass in an argument")
+		return errors.New("incorrect argument, you need to pass in an argument")
 	}
 
 	arg := args[0]
 	out := generateTargetFile
 	if err := generate(arg, out); err != nil {
-		return fmt.Errorf("error: handling generate, %v", err)
+		return fmt.Errorf("handling generate, %v", err)
 	}
 
 	return nil

--- a/internal/cli/preview.go
+++ b/internal/cli/preview.go
@@ -22,7 +22,6 @@ var (
 This allows you to find what the file looks like after ` + "`update`" + ` or ` + "`purge`" + `.
 `,
 		RunE: executePreview,
-		// TODO: Add flags to see only specific preview (e.g. `importer preview file --update` for update only view)
 		// TODO: Add support for diff preview
 	}
 	previewPurge   bool
@@ -38,6 +37,7 @@ func init() {
 
 func executePreview(cmd *cobra.Command, args []string) error {
 	// TODO: add some util func to hande all common error cases
+
 	if len(args) != 1 {
 		return errors.New("error: incorrect argument, you can only pass in 1 argument")
 	}

--- a/internal/cli/preview.go
+++ b/internal/cli/preview.go
@@ -42,6 +42,9 @@ func executePreview(cmd *cobra.Command, args []string) error {
 		return errors.New("error: incorrect argument, you can only pass in 1 argument")
 	}
 
+	// Suppress usage message after this point
+	cmd.SilenceUsage = true
+
 	arg := args[0]
 	if err := preview(arg); err != nil {
 		return fmt.Errorf("error: handling preview, %v", err)

--- a/internal/cli/purge.go
+++ b/internal/cli/purge.go
@@ -35,6 +35,9 @@ func executePurge(cmd *cobra.Command, args []string) error {
 		return errors.New("missing file input")
 	}
 
+	// Suppress usage message after this point
+	cmd.SilenceUsage = true
+
 	for _, file := range args {
 		if err := purge(file); err != nil {
 			fmt.Printf("Warning: failed to purge for '%s', %v", file, err)

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -36,6 +36,9 @@ func executeUpdate(cmd *cobra.Command, args []string) error {
 		return errors.New("missing file input")
 	}
 
+	// Suppress usage message after this point
+	cmd.SilenceUsage = true
+
 	for _, file := range args {
 		if err := update(file); err != nil {
 			fmt.Printf("Warning: failed to generate for '%s', %v", file, err)

--- a/internal/file/replace.go
+++ b/internal/file/replace.go
@@ -26,71 +26,42 @@ func WithForce() ReplaceOption {
 }
 
 // ReplaceWithAfter replaces the original file content with the processed
-// content. This is done by creating a temp file first, and replacing it.
-//
-// TODO: Ensure file mode is kept, or clarify in the comment.
+// content.
 func (f *File) ReplaceWithAfter(options ...ReplaceOption) error {
 	mode := &replaceMode{}
 	for _, opt := range options {
 		opt(mode)
 	}
 
-	file, err := os.CreateTemp("/tmp/", "importer_replace_*")
-	if err != nil {
-		return err // TODO: test coverage
-	}
-	defer file.Close()
-
-	_, err = file.Write(f.ContentAfter)
-	if err != nil {
-		return err // TODO: test coverage
-	}
-
-	// Exit early if dry-run
-	if mode.isDryRun {
-		return nil
-	}
-
-	err = os.Rename(file.Name(), f.FileName)
-	if err != nil {
-		return err // TODO: test coverage
-	}
-
-	return nil
+	return replace(f.FileName, f.ContentAfter, mode)
 }
 
 // ReplaceWithAfter replaces the original file content with the processed
-// content. This is done by creating a temp file first, and replacing it.
-//
-// TODO: Ensure file mode is kept, or clarify in the comment.
+// content.
 func (f *File) ReplaceWithPurged(options ...ReplaceOption) error {
 	mode := &replaceMode{}
 	for _, opt := range options {
 		opt(mode)
 	}
 
-	file, err := os.CreateTemp("/tmp/", "importer_replace_*")
-	if err != nil {
-		return err // TODO: test coverage
-	}
-	defer file.Close()
-
 	data := strings.Join(f.ContentPurged, "\n")
 	data = data + "\n" // Make sure to add new line at the end of the file
-	_, err = file.WriteString(data)
-	if err != nil {
-		return err // TODO: test coverage
-	}
 
+	return replace(f.FileName, []byte(data), mode)
+}
+
+func replace(fileName string, content []byte, mode *replaceMode) error {
 	// Exit early if dry-run
 	if mode.isDryRun {
 		return nil
 	}
 
-	err = os.Rename(file.Name(), f.FileName)
+	file, err := os.OpenFile(fileName, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
-		return err // TODO: test coverage
+		return err
 	}
+	defer file.Close()
 
-	return nil
+	_, err = file.Write(content)
+	return err
 }

--- a/internal/file/write.go
+++ b/internal/file/write.go
@@ -2,25 +2,14 @@ package file
 
 import "os"
 
-// WriteAfterTo takes the processed content and copies into provided filepath.
-//
-// TODO: Ensure file mode is kept, or clarify in the comment.
+// WriteAfterTo writes the processed content to the provided filepath.
 func (f *File) WriteAfterTo(filepath string) error {
-	file, err := os.CreateTemp("/tmp/", "importer_replace_*")
+	file, err := os.OpenFile(filepath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
-		return err // TODO: test coverage
+		return err
 	}
 	defer file.Close()
 
 	_, err = file.Write(f.ContentAfter)
-	if err != nil {
-		return err // TODO: test coverage
-	}
-
-	err = os.Rename(file.Name(), filepath)
-	if err != nil {
-		return err // TODO: test coverage
-	}
-
-	return nil
+	return err
 }

--- a/internal/parse/parse_error_test.go
+++ b/internal/parse/parse_error_test.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"strings"
 	"testing"
+
+	"github.com/upsidr/importer/internal/testingutil/golden"
 )
 
 func TestParseFail(t *testing.T) {
@@ -25,6 +27,11 @@ func TestParseFail(t *testing.T) {
 			fileName: "dummy.md",
 			input:    nil,
 			wantErr:  ErrNoInput,
+		},
+		"invalid marker setup": {
+			fileName: "dummy.md",
+			input:    strings.NewReader(golden.FileAsString(t, "./testdata/other/duplicated-marker.md")),
+			wantErr:  ErrDuplicatedMarker,
 		},
 	}
 

--- a/internal/parse/testdata/other/duplicated-marker.md
+++ b/internal/parse/testdata/other/duplicated-marker.md
@@ -1,0 +1,13 @@
+# Test Markdown
+
+<!-- == imptr: some_importer / begin from: ../../testdata/markdown/simple-before-importer.md#1~2 == -->
+
+some data between an annotation pair, which gets purged.
+
+<!-- == imptr: some_importer / end == -->
+
+<!-- == imptr: some_importer / begin from: ../../testdata/markdown/simple-before-importer.md#3~4 == -->
+
+another data
+
+<!-- == imptr: some_importer / end == -->


### PR DESCRIPTION
Fixed

- File mode will be kept for `importer update` and `importer purge`
- File mode will be set to 0644 for `importer generate -o`
- Importer marker processing error will no longer show usage info
- Remove redundant error message

Added

- Validation for the same name importer marker being duplicated