### PR TITLE
Refactor with extendable setup for Exporter handling

### DIFF
--- a/.github/workflows/importer-ci.yaml
+++ b/.github/workflows/importer-ci.yaml
@@ -31,8 +31,12 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
       - name: Run Go Build
         run: go build ./cmd/importer/
+
+      # These use locally built Importer, take off `./` for usual use cases
       - name: Run Importer against README.md
-        run: ./importer update README.md # This uses locally built Importer, take off `./` for usual use cases
+        run: ./importer update README.md
+      - name: Run Importer against README.md
+        run: ./importer update .github/workflows/merge-gatekeeper.yaml
 
       - name: Check if README.md has any change compared to the branch
         run: |

--- a/.github/workflows/merge-gatekeeper.yaml
+++ b/.github/workflows/merge-gatekeeper.yaml
@@ -1,0 +1,19 @@
+# == imptr: merge-gatekeeper / begin from: https://github.com/upsidr/merge-gatekeeper/blob/main/example/definitions.yaml#[standard-setup] ==
+---
+name: Merge Gatekeeper
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+
+jobs:
+  merge-gatekeeper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Merge Gatekeeper
+        uses: upsidr/merge-gatekeeper@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+# == imptr: merge-gatekeeper / end ==

--- a/internal/marker/indent.go
+++ b/internal/marker/indent.go
@@ -21,6 +21,7 @@ func adjustIndentation(lineData []byte, exporterMarkerIndent int, importerIndent
 		lineData = prependWhitespaces(lineData, importerIndentation.Length)
 	case AlignIndentation:
 		lineData = handleAbsoluteIndentation(lineData, exporterMarkerIndent, importerIndentation.MarkerIndentation)
+	case KeepIndentation: // Explicitly handling this, as it is likely that the default behaviour woulld need to change
 	}
 	lineData = append(lineData, br)
 	return lineData

--- a/internal/marker/marker.go
+++ b/internal/marker/marker.go
@@ -43,6 +43,7 @@ const (
 	AbsoluteIndentation IndentationMode = iota + 1
 	ExtraIndentation
 	AlignIndentation
+	KeepIndentation
 )
 
 // Indentation holds additional indentation handling option.


### PR DESCRIPTION
Refactored

- Use regexpplus instead of regexp, so that the regexp group ordering won't cause any issues

Added

- Additional indentation mode of Keep indent
- Merge Gatekeeper for better PR merge control
- Importer Update to run against Merge Gatekeeper