### PR TITLE
Support more keywords

### DIFF
--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -33,6 +33,10 @@ func TestGenerateStdout(t *testing.T) {
 			inputFile: "../../testdata/markdown/import-with-exporter-before.md",
 			wantFile:  "../../testdata/markdown/import-with-exporter-updated.md",
 		},
+		"yaml with exporter": {
+			inputFile: "../../testdata/yaml/demo-before.yaml",
+			wantFile:  "../../testdata/yaml/demo-updated.yaml",
+		},
 		"yaml with exporter and align": {
 			inputFile: "../../testdata/yaml/align-with-exporter-before.yaml",
 			wantFile:  "../../testdata/yaml/align-with-exporter-updated.yaml",

--- a/internal/marker/marker_regex.go
+++ b/internal/marker/marker_regex.go
@@ -6,10 +6,10 @@ var (
 	// Example:
 	//   <!-- == imptr: some_importer_name / begin from: ./file.txt#2~22 == -->
 	//   <!-- == imptr: some_importer_name / end == -->
-	ImporterMarkerMarkdown = `<!-- == imptr: (?P<importer_name>\S+) \/ (?P<importer_marker>begin|end)(?P<importer_option>.*) == -->`
+	ImporterMarkerMarkdown = `<!-- == (imptr|import|importer|i): (?P<importer_name>\S+) \/ (?P<importer_marker>begin|end)(?P<importer_option>.*) == -->`
 
 	// ImporterMarkerYAML is the annotation used for importer to find match.
-	ImporterMarkerYAML = `(?P<importer_marker_indentation>\s*)# == imptr: (?P<importer_name>\S+) \/ (?P<importer_marker>begin|end)(?P<importer_option>.*) ==`
+	ImporterMarkerYAML = `(?P<importer_marker_indentation>\s*)# == (imptr|import|importer|i): (?P<importer_name>\S+) \/ (?P<importer_marker>begin|end)(?P<importer_option>.*) ==`
 
 	// OptionFilePathIndicator is the pattern used for parsing Importer file options.
 	OptionFilePathIndicator = `from: (?P<importer_target_path>\S+)\s*\#(?P<importer_target_detail>[0-9a-zA-Z,-_\~]+)\s?`
@@ -28,7 +28,7 @@ var (
 	//   You can import this content by providing option such as:
 	//     ./file_path.txt#[simple_instruction]
 	//   <!-- == export: simple_instruction / end == -->
-	ExporterMarkerMarkdown = `<!-- == export: (?P<export_marker_name>\S+) \/ (?P<exporter_marker_condition>begin|end) == -->`
+	ExporterMarkerMarkdown = `<!-- == (exptr|export|exporter|e): (?P<export_marker_name>\S+) \/ (?P<exporter_marker_condition>begin|end) == -->`
 
 	// ExporterMarkerYAML is the marker used to indicate how a file can export
 	// specific sections.
@@ -39,5 +39,5 @@ var (
 	//     # == export: random_data / begin ==
 	//     random-data: this is exported
 	//     # == export: random_data / end ==
-	ExporterMarkerYAML = `(?P<export_marker_indent>\s*)# == export: (?P<export_marker_name>\S+) \/ (?P<exporter_marker_condition>begin|end) ==`
+	ExporterMarkerYAML = `(?P<export_marker_indent>\s*)# == (exptr|export|exporter|e): (?P<export_marker_name>\S+) \/ (?P<exporter_marker_condition>begin|end) ==`
 )

--- a/internal/regexpplus/map_test.go
+++ b/internal/regexpplus/map_test.go
@@ -33,6 +33,15 @@ func TestFindNamedSubgroups(t *testing.T) {
 				"a": "d", // later one takes precedence
 			},
 		},
+		"2 different named groups and 1 unnamed group": {
+			targetLine:  "abc def ghi jkl mno",
+			regexpInput: `(?P<a>a.*).*(?P<d>d)(.*)`,
+			want: map[string]string{
+				"":  "ef ghi jkl mno",
+				"a": "abc ",
+				"d": "d",
+			},
+		},
 		"2 unnamed groups": {
 			targetLine:  "abc def ghi jkl mno",
 			regexpInput: `(ab).*(de)`,

--- a/testdata/yaml/align-with-exporter-before.yaml
+++ b/testdata/yaml/align-with-exporter-before.yaml
@@ -7,11 +7,11 @@ data:
     indentation:
       for:
         demo:
-          # == imptr: abc-tree / begin from: ./snippet-with-exporter.yaml#[long-tree] indent: align ==
+          # == importer: abc-tree / begin from: ./snippet-with-exporter.yaml#[long-tree] indent: align ==
           anything: here
           would: be
           purged: by Importer
-          # == imptr: abc-tree / end ==
+          # == importer: abc-tree / end ==
 
   some-data:
     description: |

--- a/testdata/yaml/align-with-exporter-purged.yaml
+++ b/testdata/yaml/align-with-exporter-purged.yaml
@@ -7,8 +7,8 @@ data:
     indentation:
       for:
         demo:
-          # == imptr: abc-tree / begin from: ./snippet-with-exporter.yaml#[long-tree] indent: align ==
-          # == imptr: abc-tree / end ==
+          # == importer: abc-tree / begin from: ./snippet-with-exporter.yaml#[long-tree] indent: align ==
+          # == importer: abc-tree / end ==
 
   some-data:
     description: |

--- a/testdata/yaml/align-with-exporter-updated.yaml
+++ b/testdata/yaml/align-with-exporter-updated.yaml
@@ -7,7 +7,7 @@ data:
     indentation:
       for:
         demo:
-          # == imptr: abc-tree / begin from: ./snippet-with-exporter.yaml#[long-tree] indent: align ==
+          # == importer: abc-tree / begin from: ./snippet-with-exporter.yaml#[long-tree] indent: align ==
           a:
             b:
               c:
@@ -19,7 +19,7 @@ data:
                           i:
                             j:
                               k: {}
-          # == imptr: abc-tree / end ==
+          # == importer: abc-tree / end ==
 
   some-data:
     description: |

--- a/testdata/yaml/demo-before.yaml
+++ b/testdata/yaml/demo-before.yaml
@@ -1,4 +1,4 @@
 title: Demo of YAML Importer
-# == imptr: description / begin from: ./snippet-description.yaml#[for-demo] ==
+# == import: description / begin from: ./snippet-description.yaml#[for-demo] ==
 dummy: This will be replaced
-# == imptr: description / end ==
+# == import: description / end ==

--- a/testdata/yaml/demo-purged.yaml
+++ b/testdata/yaml/demo-purged.yaml
@@ -1,3 +1,3 @@
 title: Demo of YAML Importer
-# == imptr: description / begin from: ./snippet-description.yaml#[for-demo] ==
-# == imptr: description / end ==
+# == import: description / begin from: ./snippet-description.yaml#[for-demo] ==
+# == import: description / end ==

--- a/testdata/yaml/demo-updated.yaml
+++ b/testdata/yaml/demo-updated.yaml
@@ -1,7 +1,6 @@
 title: Demo of YAML Importer
-# == imptr: description / begin from: ./snippet-description.yaml#[for-demo] ==
+# == import: description / begin from: ./snippet-description.yaml#[for-demo] ==
 description: |
   This demonstrates how importing YAML snippet is made possible, without
   changing YAML handling at all.
-
-# == imptr: description / end ==
+# == import: description / end ==

--- a/testdata/yaml/k8s-color-svc-before.yaml
+++ b/testdata/yaml/k8s-color-svc-before.yaml
@@ -31,18 +31,18 @@ spec:
     spec:
       serviceAccountName: color-svc
       containers:
-        # == imptr: latest-color-svc / begin from: ./snippet-k8s-color-svc.yaml#[latest-svc] indent: align ==
+        # == i: latest-color-svc / begin from: ./snippet-k8s-color-svc.yaml#[latest-svc] indent: align ==
         - image: docker.io/rytswd/color-svc:latest
           name: color-svc
           command:
             - color-svc
           ports:
             - containerPort: 8800
-          # == imptr: latest-color-svc / end ==
+          # == i: latest-color-svc / end ==
 
           env:
-            # == imptr: color-svc-default-envs / begin from: ./snippet-k8s-color-svc.yaml#[basic-envs] indent: align ==
-            # == imptr: color-svc-default-envs / end ==
+            # == i: color-svc-default-envs / begin from: ./snippet-k8s-color-svc.yaml#[basic-envs] indent: align ==
+            # == i: color-svc-default-envs / end ==
             - name: DISABLE_RED
               value: "true"
             - name: DISABLE_GREEN
@@ -52,7 +52,7 @@ spec:
             - name: DISABLE_YELLOW
               value: "true"
 
-          # == imptr: resource-footprint / begin from: ./snippet-k8s-resource.yaml#[min-resource] indent: align ==
+          # == i: resource-footprint / begin from: ./snippet-k8s-resource.yaml#[min-resource] indent: align ==
           data: |
             this will be purged
-          # == imptr: resource-footprint / end ==
+          # == i: resource-footprint / end ==

--- a/testdata/yaml/k8s-color-svc-purged.yaml
+++ b/testdata/yaml/k8s-color-svc-purged.yaml
@@ -31,12 +31,12 @@ spec:
     spec:
       serviceAccountName: color-svc
       containers:
-        # == imptr: latest-color-svc / begin from: ./snippet-k8s-color-svc.yaml#[latest-svc] indent: align ==
-          # == imptr: latest-color-svc / end ==
+        # == i: latest-color-svc / begin from: ./snippet-k8s-color-svc.yaml#[latest-svc] indent: align ==
+          # == i: latest-color-svc / end ==
 
           env:
-            # == imptr: color-svc-default-envs / begin from: ./snippet-k8s-color-svc.yaml#[basic-envs] indent: align ==
-            # == imptr: color-svc-default-envs / end ==
+            # == i: color-svc-default-envs / begin from: ./snippet-k8s-color-svc.yaml#[basic-envs] indent: align ==
+            # == i: color-svc-default-envs / end ==
             - name: DISABLE_RED
               value: "true"
             - name: DISABLE_GREEN
@@ -46,5 +46,5 @@ spec:
             - name: DISABLE_YELLOW
               value: "true"
 
-          # == imptr: resource-footprint / begin from: ./snippet-k8s-resource.yaml#[min-resource] indent: align ==
-          # == imptr: resource-footprint / end ==
+          # == i: resource-footprint / begin from: ./snippet-k8s-resource.yaml#[min-resource] indent: align ==
+          # == i: resource-footprint / end ==

--- a/testdata/yaml/k8s-color-svc-updated.yaml
+++ b/testdata/yaml/k8s-color-svc-updated.yaml
@@ -31,24 +31,24 @@ spec:
     spec:
       serviceAccountName: color-svc
       containers:
-        # == imptr: latest-color-svc / begin from: ./snippet-k8s-color-svc.yaml#[latest-svc] indent: align ==
+        # == i: latest-color-svc / begin from: ./snippet-k8s-color-svc.yaml#[latest-svc] indent: align ==
         - image: docker.io/rytswd/color-svc:latest
           name: color-svc
           command:
             - color-svc
           ports:
             - containerPort: 8800
-          # == imptr: latest-color-svc / end ==
+          # == i: latest-color-svc / end ==
 
           env:
-            # == imptr: color-svc-default-envs / begin from: ./snippet-k8s-color-svc.yaml#[basic-envs] indent: align ==
+            # == i: color-svc-default-envs / begin from: ./snippet-k8s-color-svc.yaml#[basic-envs] indent: align ==
             - name: ENABLE_DELAY
               value: "true"
             - name: DELAY_DURATION_MILLISECOND
               value: "500"
             - name: ENABLE_CORS
               value: "true"
-            # == imptr: color-svc-default-envs / end ==
+            # == i: color-svc-default-envs / end ==
             - name: DISABLE_RED
               value: "true"
             - name: DISABLE_GREEN
@@ -58,7 +58,7 @@ spec:
             - name: DISABLE_YELLOW
               value: "true"
 
-          # == imptr: resource-footprint / begin from: ./snippet-k8s-resource.yaml#[min-resource] indent: align ==
+          # == i: resource-footprint / begin from: ./snippet-k8s-resource.yaml#[min-resource] indent: align ==
           resources:
             requests:
               cpu: 10m
@@ -66,4 +66,4 @@ spec:
             limits:
               cpu: 30m
               memory: 30Mi
-          # == imptr: resource-footprint / end ==
+          # == i: resource-footprint / end ==

--- a/testdata/yaml/snippet-k8s-color-svc.yaml
+++ b/testdata/yaml/snippet-k8s-color-svc.yaml
@@ -1,33 +1,33 @@
 containers:
-  # == export: latest-svc / begin ==
+  # == e: latest-svc / begin ==
   - image: docker.io/rytswd/color-svc:latest
     name: color-svc
     command:
       - color-svc
     ports:
       - containerPort: 8800
-  # == export: latest-svc / end ==
+  # == e: latest-svc / end ==
 
-  # == export: v0.1.0 / begin ==
+  # == e: v0.1.0 / begin ==
   - image: docker.io/rytswd/color-svc:0.1.0
     name: color-svc
     command:
       - color-svc
     ports:
       - containerPort: 8800
-  # == export: v0.1.0 / end ==
+  # == e: v0.1.0 / end ==
 
 envs:
-  # == export: basic-envs / begin ==
+  # == e: basic-envs / begin ==
   - name: ENABLE_DELAY
     value: "true"
   - name: DELAY_DURATION_MILLISECOND
     value: "500"
   - name: ENABLE_CORS
     value: "true"
-  # == export: basic-envs / end ==
+  # == e: basic-envs / end ==
 
-  # == export: disable-all-colours / begin ==
+  # == e: disable-all-colours / begin ==
   - name: DISABLE_RED
     value: "true"
   - name: DISABLE_GREEN
@@ -36,4 +36,4 @@ envs:
     value: "true"
   - name: DISABLE_YELLOW
     value: "true"
-  # == export: disable-all-colours / end ==
+  # == e: disable-all-colours / end ==

--- a/testdata/yaml/snippet-k8s-resource.yaml
+++ b/testdata/yaml/snippet-k8s-resource.yaml
@@ -1,5 +1,5 @@
 minimal:
-  # == export: min-resource / begin ==
+  # == exptr: min-resource / begin ==
   resources:
     requests:
       cpu: 10m
@@ -7,4 +7,4 @@ minimal:
     limits:
       cpu: 30m
       memory: 30Mi
-  # == export: min-resource / end ==
+  # == exptr: min-resource / end ==

--- a/testdata/yaml/snippet-with-exporter.yaml
+++ b/testdata/yaml/snippet-with-exporter.yaml
@@ -18,7 +18,7 @@ test-data:
       # == export: metadata-only / end ==
   # == export: sample-nested / end ==
 
-# == export: long-tree / begin ==
+# == exporter: long-tree / begin ==
 a:
   b:
     c:
@@ -30,4 +30,4 @@ a:
                 i:
                   j:
                     k: {}
-# == export: long-tree / end ==
+# == exporter: long-tree / end ==


### PR DESCRIPTION
Fixes #48 

Updated

- Instead of using `imptr` and `export` keywords explicitly, we now support `import`, `importer`, `imptr` and `i` for Importer Marker, and `export`, `exporter`, `exptr` and `e` for Exporter Marker
- Adjusted some test cases to use the new marker keywords