### PR TITLE
Fix mismatching marker handling, add better error handling

### DIFF
--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -44,7 +44,7 @@ func executeGenerate(cmd *cobra.Command, args []string) error {
 	arg := args[0]
 	out := generateTargetFile
 	if err := generate(arg, out); err != nil {
-		return fmt.Errorf("handling generate, %v", err)
+		return fmt.Errorf("failed to generate for '%s', %v", arg, err)
 	}
 
 	return nil

--- a/internal/cli/purge.go
+++ b/internal/cli/purge.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/upsidr/importer/internal/errorsplus"
 	"github.com/upsidr/importer/internal/file"
 	"github.com/upsidr/importer/internal/parse"
 )
@@ -38,10 +39,14 @@ func executePurge(cmd *cobra.Command, args []string) error {
 	// Suppress usage message after this point
 	cmd.SilenceUsage = true
 
+	errs := errorsplus.Errors{}
 	for _, file := range args {
 		if err := purge(file); err != nil {
-			fmt.Printf("Warning: failed to purge for '%s', %v", file, err)
+			errs = append(errs, fmt.Errorf("failed to update '%s', %v", file, err))
 		}
+	}
+	if len(errs) != 0 {
+		return errs
 	}
 
 	return nil

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/upsidr/importer/internal/errorsplus"
 	"github.com/upsidr/importer/internal/file"
 	"github.com/upsidr/importer/internal/parse"
 )
@@ -39,10 +40,14 @@ func executeUpdate(cmd *cobra.Command, args []string) error {
 	// Suppress usage message after this point
 	cmd.SilenceUsage = true
 
+	errs := errorsplus.Errors{}
 	for _, file := range args {
 		if err := update(file); err != nil {
-			fmt.Printf("Warning: failed to generate for '%s', %v", file, err)
+			errs = append(errs, fmt.Errorf("failed to update '%s', %v", file, err))
 		}
+	}
+	if len(errs) != 0 {
+		return errs
 	}
 
 	return nil

--- a/internal/errorsplus/composite_errors.go
+++ b/internal/errorsplus/composite_errors.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 )
 
+// Errors represents a slice of errors.
 type Errors []error
 
 func (es Errors) Error() string {
@@ -15,7 +16,7 @@ func (es Errors) Error() string {
 		return fmt.Sprintf("%v", es[0])
 	}
 
-	rt := "composite error:"
+	rt := "more than one error occurred:"
 	for _, e := range es {
 		if e != nil {
 			rt = fmt.Sprintf("%s\n\t%v", rt, e)

--- a/internal/errorsplus/composite_errors.go
+++ b/internal/errorsplus/composite_errors.go
@@ -1,0 +1,38 @@
+package errorsplus
+
+import (
+	"errors"
+	"fmt"
+)
+
+type Errors []error
+
+func (es Errors) Error() string {
+	switch len(es) {
+	case 0:
+		return ""
+	case 1:
+		return fmt.Sprintf("%v", es[0])
+	}
+
+	rt := "composite error:"
+	for _, e := range es {
+		if e != nil {
+			rt = fmt.Sprintf("%s\n\t%v", rt, e)
+		}
+	}
+	return rt
+}
+
+func (es Errors) Is(target error) bool {
+	if len(es) == 0 {
+		return false
+	}
+
+	for _, e := range es {
+		if errors.Is(e, target) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/errorsplus/composite_errors_test.go
+++ b/internal/errorsplus/composite_errors_test.go
@@ -42,7 +42,7 @@ func TestCompositeErrors(t *testing.T) {
 				errSecond,
 			},
 			wantErr: errFirst,
-			wantErrString: `composite error:
+			wantErrString: `more than one error occurred:
 	first error
 	second error`,
 		},
@@ -53,7 +53,7 @@ func TestCompositeErrors(t *testing.T) {
 				errThird,
 			},
 			wantErr: errFirst,
-			wantErrString: `composite error:
+			wantErrString: `more than one error occurred:
 	first error
 	second error
 	third error`,
@@ -65,7 +65,7 @@ func TestCompositeErrors(t *testing.T) {
 				errFirst,
 			},
 			wantErr: errFirst,
-			wantErrString: `composite error:
+			wantErrString: `more than one error occurred:
 	first error
 	first error
 	first error`,

--- a/internal/errorsplus/composite_errors_test.go
+++ b/internal/errorsplus/composite_errors_test.go
@@ -1,0 +1,122 @@
+package errorsplus_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/upsidr/importer/internal/errorsplus"
+)
+
+var (
+	errFirst  = errors.New("first error")
+	errSecond = errors.New("second error")
+	errThird  = errors.New("third error")
+	errOther  = errors.New("some other error")
+)
+
+func TestCompositeErrors(t *testing.T) {
+	cases := map[string]struct {
+		errs          errorsplus.Errors
+		wantErr       error
+		wantErrString string
+	}{
+		"zero error": {
+			errs: errorsplus.Errors{
+				// empty
+			},
+			wantErr:       nil, // cannot be checked against nil, this is skipped explicitly below
+			wantErrString: "",  // empty
+		},
+		"single error": {
+			errs: errorsplus.Errors{
+				errFirst,
+			},
+			wantErr:       errFirst,
+			wantErrString: "first error",
+		},
+		"2 errors": {
+			errs: errorsplus.Errors{
+				errFirst,
+				errSecond,
+			},
+			wantErr: errFirst,
+			wantErrString: `composite error:
+	first error
+	second error`,
+		},
+		"3 errors": {
+			errs: errorsplus.Errors{
+				errFirst,
+				errSecond,
+				errThird,
+			},
+			wantErr: errFirst,
+			wantErrString: `composite error:
+	first error
+	second error
+	third error`,
+		},
+		"duplicated errors": {
+			errs: errorsplus.Errors{
+				errFirst,
+				errFirst,
+				errFirst,
+			},
+			wantErr: errFirst,
+			wantErrString: `composite error:
+	first error
+	first error
+	first error`,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if tc.wantErr != nil && !errors.Is(tc.errs, tc.wantErr) {
+				t.Errorf("error mismatch\n\tcomposite error: %v\n\twanted error: %v", tc.errs, tc.wantErr)
+			}
+
+			errString := tc.errs.Error()
+			if diff := cmp.Diff(tc.wantErrString, errString); diff != "" {
+				t.Errorf("result didn't match (-want / +got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCompositeErrorsMismatch(t *testing.T) {
+	cases := map[string]struct {
+		errs          errorsplus.Errors
+		mismatchedErr error
+	}{
+		"zero error": {
+			errs: errorsplus.Errors{
+				// empty
+			},
+			mismatchedErr: errOther,
+		},
+		"single error": {
+			errs: errorsplus.Errors{
+				errFirst,
+			},
+			mismatchedErr: errOther,
+		},
+		"2 errors": {
+			errs: errorsplus.Errors{
+				errFirst,
+				errSecond,
+			},
+			mismatchedErr: errOther,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if errors.Is(tc.errs, tc.mismatchedErr) {
+				t.Errorf("unexpected error match, where it should not be matched with errors.Is\n\tcomposite error: %v\n\ttarget error: %v", tc.errs, tc.mismatchedErr)
+			}
+		})
+	}
+}

--- a/internal/marker/errors.go
+++ b/internal/marker/errors.go
@@ -7,7 +7,7 @@ var (
 	ErrNoInput             = errors.New("no file content found")
 	ErrInvalidPath         = errors.New("invalid path provided")
 	ErrInvalidSyntax       = errors.New("invalid syntax given")
-	ErrNoMatchingMarker    = errors.New("no matching marker found, marker must be a begin/end pair")
+	ErrNoMatchingMarker    = errors.New("no matching marker found")
 	ErrMissingOption       = errors.New("missing option")
 	ErrMissingName         = errors.New("unnamed marker cannot be used")
 	ErrNoFileInput         = errors.New("no target file input provided")

--- a/internal/marker/marker_regex.go
+++ b/internal/marker/marker_regex.go
@@ -15,7 +15,7 @@ var (
 	OptionFilePathIndicator = `from: (?P<importer_target_path>\S+)\s*\#(?P<importer_target_detail>[0-9a-zA-Z,-_\~]+)\s?`
 
 	// OptionIndentMode is the pattern used for specifying indentation mode.
-	OptionIndentMode = `indent: (?P<importer_indent_mode>absolute|extra|align)\s?(?P<importer_indent_length>\d*)`
+	OptionIndentMode = `indent: (?P<importer_indent_mode>absolute|extra|align|keep)\s?(?P<importer_indent_length>\d*)`
 )
 
 var (

--- a/internal/marker/marker_test.go
+++ b/internal/marker/marker_test.go
@@ -120,6 +120,45 @@ func TestNewMarker(t *testing.T) {
 				},
 			},
 		},
+		"Exporter with indent align": {
+			input: &marker.RawMarker{
+				Name:                 "simple-marker",
+				IsBeginFound:         true,
+				IsEndFound:           true,
+				LineToInsertAt:       3,
+				Options:              "from: ./abc.yaml#[from-exporter-marker] indent: align",
+				PrecedingIndentation: "    ",
+			},
+			want: &marker.Marker{
+				Name:               "simple-marker",
+				LineToInsertAt:     3,
+				TargetPath:         "./abc.yaml",
+				TargetExportMarker: "from-exporter-marker",
+				Indentation: &marker.Indentation{
+					Mode:              marker.AlignIndentation,
+					MarkerIndentation: 4,
+				},
+			},
+		},
+		"Exporter with indent keep": {
+			input: &marker.RawMarker{
+				Name:                 "simple-marker",
+				IsBeginFound:         true,
+				IsEndFound:           true,
+				LineToInsertAt:       3,
+				Options:              "from: ./abc.yaml#[from-exporter-marker] indent: keep",
+				PrecedingIndentation: "    ",
+			},
+			want: &marker.Marker{
+				Name:               "simple-marker",
+				LineToInsertAt:     3,
+				TargetPath:         "./abc.yaml",
+				TargetExportMarker: "from-exporter-marker",
+				Indentation: &marker.Indentation{
+					Mode: marker.KeepIndentation,
+				},
+			},
+		},
 	}
 
 	for name, tc := range cases {

--- a/internal/marker/raw_marker.go
+++ b/internal/marker/raw_marker.go
@@ -21,7 +21,7 @@ func (r *RawMarker) Validate() error {
 	}
 
 	if !r.IsBeginFound || !r.IsEndFound {
-		return fmt.Errorf("%w", ErrNoMatchingMarker)
+		return fmt.Errorf("%w for '%s', marker must be a begin/end pair", ErrNoMatchingMarker, r.Name)
 	}
 
 	return nil

--- a/internal/marker/raw_marker.go
+++ b/internal/marker/raw_marker.go
@@ -17,7 +17,7 @@ type RawMarker struct {
 // Validate checks RawMarker's validity.
 func (r *RawMarker) Validate() error {
 	if r.Name == "" {
-		return fmt.Errorf("%w", ErrMissingName)
+		return fmt.Errorf("%w", ErrMissingName) // Should not happen with the current regexp setup
 	}
 
 	if !r.IsBeginFound || !r.IsEndFound {

--- a/internal/parse/parse_error_test.go
+++ b/internal/parse/parse_error_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/upsidr/importer/internal/marker"
 	"github.com/upsidr/importer/internal/testingutil/golden"
 )
 
@@ -18,6 +19,11 @@ func TestParseFail(t *testing.T) {
 		// Output
 		wantErr error
 	}{
+		"broken marker": {
+			fileName: "dummy.yaml",
+			input:    strings.NewReader(golden.FileAsString(t, "../../testdata/broken/no-matching-marker.yaml")),
+			wantErr:  marker.ErrNoMatchingMarker,
+		},
 		"extension not supported": {
 			fileName: "no_extension",
 			input:    strings.NewReader("dummy"),

--- a/internal/parse/parse_yaml_test.go
+++ b/internal/parse/parse_yaml_test.go
@@ -1,6 +1,7 @@
 package parse
 
 import (
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -85,81 +86,6 @@ data:
 				},
 			},
 		},
-
-		// ===================
-		// Invalid cases below
-		"importer option missing": {
-			fileName: "dummy.yaml",
-			input: strings.NewReader(`
-data:
-  # == imptr: some_importer / begin ==
-  content-to-be-purged: this will be removed
-  # == imptr: some_importer / end ==
-`),
-			wantFile: &file.File{
-				FileName: "dummy.yaml",
-				ContentBefore: StringToLineStrings(t, `
-data:
-  # == imptr: some_importer / begin ==
-  content-to-be-purged: this will be removed
-  # == imptr: some_importer / end ==
-`),
-				ContentPurged: StringToLineStrings(t, `
-data:
-  # == imptr: some_importer / begin ==
-  # == imptr: some_importer / end ==
-`),
-				Markers: map[int]*marker.Marker{},
-			},
-		},
-		"file line range not number - lower bound": {
-			fileName: "dummy.yaml",
-			input: strings.NewReader(`
-data:
-  # == imptr: some_importer / begin from: ./somefile#NOT_NUMBER~2233 ==
-  content-to-be-purged: this will be removed
-  # == imptr: some_importer / end == -->
-`),
-			wantFile: &file.File{
-				FileName: "dummy.yaml",
-				ContentBefore: StringToLineStrings(t, `
-data:
-  # == imptr: some_importer / begin from: ./somefile#NOT_NUMBER~2233 ==
-  content-to-be-purged: this will be removed
-  # == imptr: some_importer / end == -->
-`),
-				ContentPurged: StringToLineStrings(t, `
-data:
-  # == imptr: some_importer / begin from: ./somefile#NOT_NUMBER~2233 ==
-  # == imptr: some_importer / end == -->
-`),
-				Markers: map[int]*marker.Marker{},
-			},
-		},
-		"file line range not number - upper bound": {
-			fileName: "dummy.yaml",
-			input: strings.NewReader(`
-data:
-  # == imptr: some_importer / begin from: ./somefile#1~NOT_NUMBER ==
-  content-to-be-purged: this will be removed
-  # == imptr: some_importer / end ==
-`),
-			wantFile: &file.File{
-				FileName: "dummy.yaml",
-				ContentBefore: StringToLineStrings(t, `
-data:
-  # == imptr: some_importer / begin from: ./somefile#1~NOT_NUMBER ==
-  content-to-be-purged: this will be removed
-  # == imptr: some_importer / end ==
-`),
-				ContentPurged: StringToLineStrings(t, `
-data:
-  # == imptr: some_importer / begin from: ./somefile#1~NOT_NUMBER ==
-  # == imptr: some_importer / end ==
-`),
-				Markers: map[int]*marker.Marker{},
-			},
-		},
 	}
 
 	for name, tc := range cases {
@@ -176,6 +102,61 @@ data:
 
 			if diff := cmp.Diff(tc.wantFile, f, cmp.AllowUnexported(file.File{})); diff != "" {
 				t.Errorf("parsed result didn't match (-want / +got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestParseYAMLFail(t *testing.T) {
+	cases := map[string]struct {
+		// Input
+		fileName string
+		input    io.Reader
+
+		// Output
+		wantErr error
+	}{
+		"importer option missing": {
+			fileName: "dummy.yaml",
+			input: strings.NewReader(`
+data:
+  # == imptr: some_importer / begin ==
+  content-to-be-purged: this will be removed
+  # == imptr: some_importer / end ==
+`),
+			wantErr: marker.ErrInvalidSyntax,
+		},
+		"file line range not number - lower bound": {
+			fileName: "dummy.yaml",
+			input: strings.NewReader(`
+data:
+  # == imptr: some_importer / begin from: ./somefile#NOT_NUMBER~2233 ==
+  content-to-be-purged: this will be removed
+  # == imptr: some_importer / end == -->
+`),
+			wantErr: marker.ErrInvalidSyntax,
+		},
+		"file line range not number - upper bound": {
+			fileName: "dummy.yaml",
+			input: strings.NewReader(`
+data:
+  # == imptr: some_importer / begin from: ./somefile#1~NOT_NUMBER ==
+  content-to-be-purged: this will be removed
+  # == imptr: some_importer / end ==
+`),
+			wantErr: marker.ErrInvalidSyntax,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			fileInput := tc.input
+			if fileInput == nil {
+				fileInput = golden.FileAsReader(t, tc.fileName)
+			}
+			_, err := Parse(tc.fileName, fileInput)
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("error did not match:\n    want: %v\n    got:  %v", tc.wantErr, err)
 			}
 		})
 	}

--- a/testdata/broken/no-matching-marker.yaml
+++ b/testdata/broken/no-matching-marker.yaml
@@ -1,0 +1,4 @@
+title: Demo of YAML Importer
+# == import: description / begin from: ./snippet-description.yaml#[for-demo] ==
+dummy: This will be replaced
+# == this is not a valid marker, and thus marker pair is broken ==

--- a/testdata/yaml/keep-indentation-explicit-before.yaml
+++ b/testdata/yaml/keep-indentation-explicit-before.yaml
@@ -1,0 +1,14 @@
+data:
+  description: |
+    This is to demonstrate how Importer can manage your YAML files.
+    ...
+
+  # == imptr: metadata / begin from: ./snippet-with-exporter.yaml#[metadata-only] indent: keep ==
+  anything: here
+  would: be
+  purged: by Importer
+  # == imptr: metadata / end ==
+
+  some-data:
+    description: |
+      any data outside of Importer Markers are unaffected.

--- a/testdata/yaml/keep-indentation-explicit-purged.yaml
+++ b/testdata/yaml/keep-indentation-explicit-purged.yaml
@@ -1,0 +1,11 @@
+data:
+  description: |
+    This is to demonstrate how Importer can manage your YAML files.
+    ...
+
+  # == imptr: metadata / begin from: ./snippet-with-exporter.yaml#[metadata-only] indent: keep ==
+  # == imptr: metadata / end ==
+
+  some-data:
+    description: |
+      any data outside of Importer Markers are unaffected.

--- a/testdata/yaml/keep-indentation-explicit-updated.yaml
+++ b/testdata/yaml/keep-indentation-explicit-updated.yaml
@@ -1,0 +1,13 @@
+data:
+  description: |
+    This is to demonstrate how Importer can manage your YAML files.
+    ...
+  # == imptr: metadata / begin from: ./snippet-with-exporter.yaml#[metadata-only] indent: keep ==
+      metadata:
+        name: sample-data
+        namespace: sample-namespace
+  # == imptr: metadata / end ==
+
+  some-data:
+    description: |
+      any data outside of Importer Markers are unaffected.


### PR DESCRIPTION
Fixes #46 

Fixed

- Error handling when marker is invalid - error would stop further processing of the file
- Error message is now consistent and more meaningful

Added

- Indentation mode of Keep, which is the same as the current default behaviour
- More test coverage