### PR TITLE
Add flag to disable writing header

### DIFF
--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -24,13 +24,15 @@ This approach allows the input file to be full of Importer markes without actual
 		Args: cobra.MinimumNArgs(1),
 		RunE: executeGenerate,
 	}
-	generateTargetFile  string
-	generateKeepMarkers bool
+	generateTargetFile    string
+	generateKeepMarkers   bool
+	generateDisableHeader bool
 )
 
 func init() {
 	generateCliCmd.Flags().StringVarP(&generateTargetFile, "out", "o", "", "write to `FILE`")
 	generateCliCmd.Flags().BoolVar(&generateKeepMarkers, "keep-markers", false, "keep Importer Markers from the generated result")
+	generateCliCmd.Flags().BoolVar(&generateDisableHeader, "disable-header", false, "disable automatically added header of Importer generated notice")
 }
 
 func executeGenerate(cmd *cobra.Command, args []string) error {
@@ -75,7 +77,7 @@ func generate(fileName string, targetFilepath string, keepMarkers bool) error {
 	}
 
 	if targetFilepath != "" {
-		return file.WriteAfterTo(targetFilepath)
+		return file.WriteAfterTo(targetFilepath, generateDisableHeader)
 	}
 
 	return file.PrintAfter()

--- a/internal/file/write.go
+++ b/internal/file/write.go
@@ -7,12 +7,18 @@ import (
 )
 
 // WriteAfterTo writes the processed content to the provided filepath.
-func (f *File) WriteAfterTo(targetFilePath string) error {
+func (f *File) WriteAfterTo(targetFilePath string, disableHeader bool) error {
 	file, err := os.OpenFile(targetFilePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return err
 	}
 	defer file.Close()
+
+	// If no header is needed, simply write the updated content and complete.
+	if disableHeader {
+		_, err = file.Write(f.ContentAfter)
+		return err
+	}
 
 	content := []byte{}
 	content = append(content, f.prepareGeneratedHeader(targetFilePath)...)


### PR DESCRIPTION
Fixes #35 

Added

- New flag `--disable-header` for removing `importer-generated-from` marker

This is likely only useful when Importer is used for one time only. Header is often useful to track back to the original file, but it can be a noise for some.