### PR TITLE
Refactor with better use of structs for Marker

### DIFF
--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -33,7 +33,7 @@ func TestUpdate(t *testing.T) {
 
 			err := update(copiedFile)
 			if err != nil {
-				t.Fatalf("error with generate, %v", err)
+				t.Fatalf("error with update, %v", err)
 			}
 
 			if *updateGolden {

--- a/internal/file/process_test.go
+++ b/internal/file/process_test.go
@@ -30,8 +30,14 @@ func TestProcessMarker(t *testing.T) {
 					2: {
 						Name:           "test annotation",
 						LineToInsertAt: 2,
-						TargetPath:     "../../testdata/other/note.txt",
-						TargetLines:    []int{1, 2},
+						ImportTargetFile: marker.ImportTargetFile{
+							Type: marker.PathBased,
+							File: "../../testdata/other/note.txt",
+						},
+						ImportLogic: marker.ImportLogic{
+							Type:  marker.CommaSeparatedLines,
+							Lines: []int{1, 2},
+						},
 					},
 				},
 			},
@@ -54,8 +60,14 @@ data
 					2: {
 						Name:           "test annotation",
 						LineToInsertAt: 2,
-						TargetPath:     "../../does-not-exist.txt",
-						TargetLines:    []int{1, 2},
+						ImportTargetFile: marker.ImportTargetFile{
+							Type: marker.PathBased,
+							File: "../../does-not-exist.txt",
+						},
+						ImportLogic: marker.ImportLogic{
+							Type:  marker.CommaSeparatedLines,
+							Lines: []int{1, 2},
+						},
 					},
 				},
 			},

--- a/internal/marker/marker_regex.go
+++ b/internal/marker/marker_regex.go
@@ -1,5 +1,6 @@
 package marker
 
+// Importer Marker related definitions
 var (
 	// ImporterMarkerMarkdown is the annotation used for importer to find match.
 	//
@@ -16,8 +17,12 @@ var (
 
 	// OptionIndentMode is the pattern used for specifying indentation mode.
 	OptionIndentMode = `indent: (?P<importer_indent_mode>absolute|extra|align|keep)\s?(?P<importer_indent_length>\d*)`
+
+	ImporterSkipProcessingMarkdown = `<!-- == importer-skip-update == -->`
+	ImporterSkipProcessingYAML     = `# == importer-skip-update ==`
 )
 
+// Exporter Marker related definitions
 var (
 	// ExporterMarkerMarkdown is the marker used to indicate how a file can
 	// export specific sections.

--- a/internal/marker/marker_test.go
+++ b/internal/marker/marker_test.go
@@ -23,14 +23,18 @@ func TestNewMarker(t *testing.T) {
 				Options:        "from: ./abc.md#3~5",
 			},
 			want: &marker.Marker{
-				Name:               "simple-marker",
-				LineToInsertAt:     3,
-				TargetPath:         "./abc.md",
-				TargetExportMarker: "",
-				TargetLines:        nil,
-				TargetLineFrom:     3,
-				TargetLineTo:       5,
-				Indentation:        nil,
+				Name:           "simple-marker",
+				LineToInsertAt: 3,
+				ImportTargetFile: marker.ImportTargetFile{
+					Type: marker.PathBased,
+					File: "./abc.md",
+				},
+				ImportLogic: marker.ImportLogic{
+					Type:     marker.LineRange,
+					LineFrom: 3,
+					LineTo:   5,
+				},
+				Indentation: nil,
 			},
 		},
 		"Line array": {
@@ -42,12 +46,17 @@ func TestNewMarker(t *testing.T) {
 				Options:        "from: ./abc.md#3,4,5,6",
 			},
 			want: &marker.Marker{
-				Name:               "simple-marker",
-				LineToInsertAt:     3,
-				TargetPath:         "./abc.md",
-				TargetExportMarker: "",
-				TargetLines:        []int{3, 4, 5, 6},
-				Indentation:        nil,
+				Name:           "simple-marker",
+				LineToInsertAt: 3,
+				ImportTargetFile: marker.ImportTargetFile{
+					Type: marker.PathBased,
+					File: "./abc.md",
+				},
+				ImportLogic: marker.ImportLogic{
+					Type:  marker.CommaSeparatedLines,
+					Lines: []int{3, 4, 5, 6},
+				},
+				Indentation: nil,
 			},
 		},
 		"Line array with ranges": {
@@ -59,12 +68,17 @@ func TestNewMarker(t *testing.T) {
 				Options:        "from: ./abc.md#3~5,7~9",
 			},
 			want: &marker.Marker{
-				Name:               "simple-marker",
-				LineToInsertAt:     3,
-				TargetPath:         "./abc.md",
-				TargetExportMarker: "",
-				TargetLines:        []int{3, 4, 5, 7, 8, 9},
-				Indentation:        nil,
+				Name:           "simple-marker",
+				LineToInsertAt: 3,
+				ImportTargetFile: marker.ImportTargetFile{
+					Type: marker.PathBased,
+					File: "./abc.md",
+				},
+				ImportLogic: marker.ImportLogic{
+					Type:  marker.CommaSeparatedLines,
+					Lines: []int{3, 4, 5, 7, 8, 9},
+				},
+				Indentation: nil,
 			},
 		},
 		"Exporter": {
@@ -76,10 +90,16 @@ func TestNewMarker(t *testing.T) {
 				Options:        "from: ./abc.md#[from-exporter-marker]",
 			},
 			want: &marker.Marker{
-				Name:               "simple-marker",
-				LineToInsertAt:     3,
-				TargetPath:         "./abc.md",
-				TargetExportMarker: "from-exporter-marker",
+				Name:           "simple-marker",
+				LineToInsertAt: 3,
+				ImportTargetFile: marker.ImportTargetFile{
+					Type: marker.PathBased,
+					File: "./abc.md",
+				},
+				ImportLogic: marker.ImportLogic{
+					Type:           marker.ExporterMarker,
+					ExporterMarker: "from-exporter-marker",
+				},
 			},
 		},
 		"Exporter with absolute indent": {
@@ -91,10 +111,16 @@ func TestNewMarker(t *testing.T) {
 				Options:        "from: ./abc.md#[from-exporter-marker] indent: absolute 2",
 			},
 			want: &marker.Marker{
-				Name:               "simple-marker",
-				LineToInsertAt:     3,
-				TargetPath:         "./abc.md",
-				TargetExportMarker: "from-exporter-marker",
+				Name:           "simple-marker",
+				LineToInsertAt: 3,
+				ImportTargetFile: marker.ImportTargetFile{
+					Type: marker.PathBased,
+					File: "./abc.md",
+				},
+				ImportLogic: marker.ImportLogic{
+					Type:           marker.ExporterMarker,
+					ExporterMarker: "from-exporter-marker",
+				},
 				Indentation: &marker.Indentation{
 					Mode:   marker.AbsoluteIndentation,
 					Length: 2,
@@ -110,10 +136,16 @@ func TestNewMarker(t *testing.T) {
 				Options:        "from: ./abc.md#[from-exporter-marker] indent: extra 4",
 			},
 			want: &marker.Marker{
-				Name:               "simple-marker",
-				LineToInsertAt:     3,
-				TargetPath:         "./abc.md",
-				TargetExportMarker: "from-exporter-marker",
+				Name:           "simple-marker",
+				LineToInsertAt: 3,
+				ImportTargetFile: marker.ImportTargetFile{
+					Type: marker.PathBased,
+					File: "./abc.md",
+				},
+				ImportLogic: marker.ImportLogic{
+					Type:           marker.ExporterMarker,
+					ExporterMarker: "from-exporter-marker",
+				},
 				Indentation: &marker.Indentation{
 					Mode:   marker.ExtraIndentation,
 					Length: 4,
@@ -130,10 +162,16 @@ func TestNewMarker(t *testing.T) {
 				PrecedingIndentation: "    ",
 			},
 			want: &marker.Marker{
-				Name:               "simple-marker",
-				LineToInsertAt:     3,
-				TargetPath:         "./abc.yaml",
-				TargetExportMarker: "from-exporter-marker",
+				Name:           "simple-marker",
+				LineToInsertAt: 3,
+				ImportTargetFile: marker.ImportTargetFile{
+					Type: marker.PathBased,
+					File: "./abc.yaml",
+				},
+				ImportLogic: marker.ImportLogic{
+					Type:           marker.ExporterMarker,
+					ExporterMarker: "from-exporter-marker",
+				},
 				Indentation: &marker.Indentation{
 					Mode:              marker.AlignIndentation,
 					MarkerIndentation: 4,
@@ -150,10 +188,16 @@ func TestNewMarker(t *testing.T) {
 				PrecedingIndentation: "    ",
 			},
 			want: &marker.Marker{
-				Name:               "simple-marker",
-				LineToInsertAt:     3,
-				TargetPath:         "./abc.yaml",
-				TargetExportMarker: "from-exporter-marker",
+				Name:           "simple-marker",
+				LineToInsertAt: 3,
+				ImportTargetFile: marker.ImportTargetFile{
+					Type: marker.PathBased,
+					File: "./abc.yaml",
+				},
+				ImportLogic: marker.ImportLogic{
+					Type:           marker.ExporterMarker,
+					ExporterMarker: "from-exporter-marker",
+				},
 				Indentation: &marker.Indentation{
 					Mode: marker.KeepIndentation,
 				},

--- a/internal/marker/process.go
+++ b/internal/marker/process.go
@@ -96,7 +96,7 @@ func (m *Marker) processSingleMarkerMarkdown(file io.Reader) ([]byte, error) {
 			continue
 		}
 
-		// Handle export marker imports
+		// Handle Exporter Marker imports
 		if withinExportMarker {
 			result = append(result, scanner.Bytes()...)
 			result = append(result, br)

--- a/internal/marker/process.go
+++ b/internal/marker/process.go
@@ -26,8 +26,8 @@ func (m *Marker) ProcessMarkerData(importingFilePath string) ([]byte, error) {
 	switch m.ImportTargetFile.Type {
 	case PathBased:
 		// Make sure the files are read based on the relative path
-		dir := filepath.Dir(targetFile)
-		targetPath := dir + "/" + m.ImportTargetFile.File
+		dir := filepath.Dir(importingFilePath)
+		targetPath := filepath.Join(dir, targetFile)
 		f, err := os.Open(targetPath)
 		if err != nil {
 			// TODO: This note is no longer true - need to review what it was meant to be.

--- a/internal/marker/process.go
+++ b/internal/marker/process.go
@@ -21,23 +21,26 @@ import (
 // the import target.
 func (m *Marker) ProcessMarkerData(importingFilePath string) ([]byte, error) {
 	var file io.Reader
-	switch {
-	case m.TargetPath != "":
+
+	targetFile := m.ImportTargetFile.File
+	switch m.ImportTargetFile.Type {
+	case PathBased:
 		// Make sure the files are read based on the relative path
-		dir := filepath.Dir(importingFilePath)
-		targetPath := dir + "/" + m.TargetPath
+		dir := filepath.Dir(targetFile)
+		targetPath := dir + "/" + m.ImportTargetFile.File
 		f, err := os.Open(targetPath)
 		if err != nil {
+			// TODO: This note is no longer true - need to review what it was meant to be.
 			// Purposely returning the byte slice as it contains data that were
 			// populated prior to hitting this func
 			return nil, err
 		}
 		defer f.Close()
 		file = f
-	case m.TargetURL != "":
-		u, err := preprocessURL(m.TargetURL)
+	case URLBased:
+		u, err := preprocessURL(targetFile)
 		if err != nil {
-			return nil, fmt.Errorf("%w of '%s'", ErrInvalidURL, m.TargetURL)
+			return nil, fmt.Errorf("%w of '%s'", ErrInvalidURL, targetFile)
 		}
 		r, err := http.Get(u)
 		if err != nil {
@@ -83,7 +86,7 @@ func (m *Marker) processSingleMarkerMarkdown(file io.Reader) ([]byte, error) {
 
 		if len(matches) != 0 {
 			if exporterName, found := matches["export_marker_name"]; found &&
-				exporterName == m.TargetExportMarker {
+				exporterName == m.ImportLogic.ExporterMarker {
 				withinExportMarker = true
 			}
 			if exporterCondition, found := matches["exporter_marker_condition"]; found &&
@@ -101,13 +104,13 @@ func (m *Marker) processSingleMarkerMarkdown(file io.Reader) ([]byte, error) {
 		}
 
 		// Handle line number imports
-		if currentLine >= m.TargetLineFrom &&
-			currentLine <= m.TargetLineTo {
+		if currentLine >= m.ImportLogic.LineFrom &&
+			currentLine <= m.ImportLogic.LineTo {
 			result = append(result, scanner.Bytes()...)
 			result = append(result, br)
 			continue
 		}
-		for _, l := range m.TargetLines {
+		for _, l := range m.ImportLogic.Lines {
 			if currentLine == l {
 				result = append(result, scanner.Bytes()...)
 				result = append(result, br)
@@ -135,17 +138,17 @@ func (m *Marker) processSingleMarkerYAML(file io.Reader) ([]byte, error) {
 
 		switch {
 		// Handle line number range
-		case m.TargetLineFrom > 0:
-			if currentLine >= m.TargetLineFrom &&
-				currentLine <= m.TargetLineTo {
+		case m.ImportLogic.LineFrom > 0:
+			if currentLine >= m.ImportLogic.LineFrom &&
+				currentLine <= m.ImportLogic.LineTo {
 				lineData = append(lineData, br)
 				result = append(result, lineData...)
 				continue
 			}
 
 		// Handle line number slice
-		case len(m.TargetLines) > 0:
-			for _, l := range m.TargetLines {
+		case len(m.ImportLogic.Lines) > 0:
+			for _, l := range m.ImportLogic.Lines {
 				if currentLine == l {
 					lineData = append(lineData, br)
 					result = append(result, lineData...)
@@ -154,7 +157,7 @@ func (m *Marker) processSingleMarkerYAML(file io.Reader) ([]byte, error) {
 			}
 
 		// Handle ExporterMarker
-		case m.TargetExportMarker != "":
+		case m.ImportLogic.ExporterMarker != "":
 			// Find Exporter Marker
 			matches, err := regexpplus.MapWithNamedSubgroups(lineString, ExporterMarkerYAML)
 			if errors.Is(err, regexpplus.ErrNoMatch) {
@@ -172,7 +175,7 @@ func (m *Marker) processSingleMarkerYAML(file io.Reader) ([]byte, error) {
 
 			if exporterName, found := matches["export_marker_name"]; found {
 				// Ignore unrelated marker
-				if exporterName != m.TargetExportMarker || exporterName == "" {
+				if exporterName != m.ImportLogic.ExporterMarker || exporterName == "" {
 					continue
 				}
 
@@ -212,13 +215,13 @@ func (m *Marker) processSingleMarkerOther(file io.Reader) ([]byte, error) {
 		// separately.
 
 		// Handle line number imports
-		if currentLine >= m.TargetLineFrom &&
-			currentLine <= m.TargetLineTo {
+		if currentLine >= m.ImportLogic.LineFrom &&
+			currentLine <= m.ImportLogic.LineTo {
 			result = append(result, scanner.Bytes()...)
 			result = append(result, br)
 			continue
 		}
-		for _, l := range m.TargetLines {
+		for _, l := range m.ImportLogic.Lines {
 			if currentLine == l {
 				result = append(result, scanner.Bytes()...)
 				result = append(result, br)

--- a/internal/marker/process_test.go
+++ b/internal/marker/process_test.go
@@ -22,9 +22,15 @@ func TestProcessSingleMarker(t *testing.T) {
 			callerFile: "./some_file.md",
 			marker: &Marker{
 				LineToInsertAt: 1, // Not used in this, as single annotation handling is about appending data
-				TargetPath:     "../../testdata/other/note.txt",
-				TargetLineFrom: 1,
-				TargetLineTo:   3,
+				ImportTargetFile: ImportTargetFile{
+					Type: PathBased,
+					File: "../../testdata/other/note.txt",
+				},
+				ImportLogic: ImportLogic{
+					Type:     LineRange,
+					LineFrom: 1,
+					LineTo:   3,
+				},
 			},
 			want: []byte(`This is test data.
 他言語サポートのためのテスト文章。
@@ -35,8 +41,14 @@ func TestProcessSingleMarker(t *testing.T) {
 			callerFile: "./some_file.md",
 			marker: &Marker{
 				LineToInsertAt: 1,
-				TargetPath:     "../../testdata/other/note.txt",
-				TargetLines:    []int{2, 3},
+				ImportTargetFile: ImportTargetFile{
+					Type: PathBased,
+					File: "../../testdata/other/note.txt",
+				},
+				ImportLogic: ImportLogic{
+					Type:  CommaSeparatedLines,
+					Lines: []int{2, 3},
+				},
 			},
 			want: []byte(`他言語サポートのためのテスト文章。
 🍸 Emojis 🍷 Supported 🍺
@@ -45,9 +57,15 @@ func TestProcessSingleMarker(t *testing.T) {
 		"markdown: exporter marker": {
 			callerFile: "./some_file.md",
 			marker: &Marker{
-				LineToInsertAt:     1,
-				TargetPath:         "../../testdata/markdown/snippet-with-exporter.md",
-				TargetExportMarker: "test_exporter",
+				LineToInsertAt: 1,
+				ImportTargetFile: ImportTargetFile{
+					Type: PathBased,
+					File: "../../testdata/markdown/snippet-with-exporter.md",
+				},
+				ImportLogic: ImportLogic{
+					Type:           ExporterMarker,
+					ExporterMarker: "test_exporter",
+				},
 			},
 			want: []byte(`
 ✨✨✨✨✨✨✨✨
@@ -64,10 +82,16 @@ func TestProcessSingleMarker(t *testing.T) {
 			callerFile: "./some_file.yaml",
 			marker: &Marker{
 				LineToInsertAt: 5,
-				TargetPath:     "../../testdata/yaml/snippet-simple-tree.yaml",
-				TargetLineFrom: 2,
-				TargetLineTo:   5,
-				Indentation:    nil,
+				ImportTargetFile: ImportTargetFile{
+					Type: PathBased,
+					File: "../../testdata/yaml/snippet-simple-tree.yaml",
+				},
+				ImportLogic: ImportLogic{
+					Type:     LineRange,
+					LineFrom: 2,
+					LineTo:   5,
+				},
+				Indentation: nil,
 			},
 			want: []byte(`  b:
     c:
@@ -75,14 +99,20 @@ func TestProcessSingleMarker(t *testing.T) {
         e:
 `),
 		},
-		"yaml: line range with URL, github.com": {
+		"yaml: line range with URL, github.com - this may fail if GitHub is down": {
 			callerFile: "./some_file.yaml",
 			marker: &Marker{
 				LineToInsertAt: 5,
-				TargetURL:      "https://github.com/upsidr/importer/blob/main/testdata/yaml/snippet-simple-tree.yaml",
-				TargetLineFrom: 2,
-				TargetLineTo:   5,
-				Indentation:    nil,
+				ImportTargetFile: ImportTargetFile{
+					Type: URLBased,
+					File: "https://github.com/upsidr/importer/blob/main/testdata/yaml/snippet-simple-tree.yaml",
+				},
+				ImportLogic: ImportLogic{
+					Type:     LineRange,
+					LineFrom: 2,
+					LineTo:   5,
+				},
+				Indentation: nil,
 			},
 			want: []byte(`  b:
     c:
@@ -94,10 +124,16 @@ func TestProcessSingleMarker(t *testing.T) {
 			callerFile: "./some_file.yaml",
 			marker: &Marker{
 				LineToInsertAt: 5,
-				TargetURL:      "https://raw.githubusercontent.com/upsidr/importer/main/testdata/yaml/snippet-simple-tree.yaml",
-				TargetLineFrom: 2,
-				TargetLineTo:   5,
-				Indentation:    nil,
+				ImportTargetFile: ImportTargetFile{
+					Type: URLBased,
+					File: "https://raw.githubusercontent.com/upsidr/importer/main/testdata/yaml/snippet-simple-tree.yaml",
+				},
+				ImportLogic: ImportLogic{
+					Type:     LineRange,
+					LineFrom: 2,
+					LineTo:   5,
+				},
+				Indentation: nil,
 			},
 			want: []byte(`  b:
     c:
@@ -109,9 +145,15 @@ func TestProcessSingleMarker(t *testing.T) {
 			callerFile: "./some_file.yaml",
 			marker: &Marker{
 				LineToInsertAt: 5,
-				TargetPath:     "../../testdata/yaml/snippet-simple-tree.yaml",
-				TargetLines:    []int{1, 2, 4},
-				Indentation:    nil,
+				ImportTargetFile: ImportTargetFile{
+					Type: PathBased,
+					File: "../../testdata/yaml/snippet-simple-tree.yaml",
+				},
+				ImportLogic: ImportLogic{
+					Type:  LineRange,
+					Lines: []int{1, 2, 4},
+				},
+				Indentation: nil,
 			},
 			want: []byte(`a:
   b:
@@ -121,10 +163,16 @@ func TestProcessSingleMarker(t *testing.T) {
 		"yaml: exporter marker": {
 			callerFile: "./some_file.yaml",
 			marker: &Marker{
-				LineToInsertAt:     5,
-				TargetPath:         "../../testdata/yaml/snippet-with-exporter.yaml",
-				TargetExportMarker: "long-tree",
-				Indentation:        nil,
+				LineToInsertAt: 5,
+				ImportTargetFile: ImportTargetFile{
+					Type: PathBased,
+					File: "../../testdata/yaml/snippet-with-exporter.yaml",
+				},
+				ImportLogic: ImportLogic{
+					Type:           ExporterMarker,
+					ExporterMarker: "long-tree",
+				},
+				Indentation: nil,
 			},
 			want: []byte(`a:
   b:
@@ -142,9 +190,15 @@ func TestProcessSingleMarker(t *testing.T) {
 		"yaml: exporter marker with absolute indentation": {
 			callerFile: "./some_file.yaml",
 			marker: &Marker{
-				LineToInsertAt:     5,
-				TargetPath:         "../../testdata/yaml/snippet-with-exporter.yaml",
-				TargetExportMarker: "metadata-only",
+				LineToInsertAt: 5,
+				ImportTargetFile: ImportTargetFile{
+					Type: PathBased,
+					File: "../../testdata/yaml/snippet-with-exporter.yaml",
+				},
+				ImportLogic: ImportLogic{
+					Type:           ExporterMarker,
+					ExporterMarker: "metadata-only",
+				},
 				Indentation: &Indentation{
 					Mode:   AbsoluteIndentation,
 					Length: 30,
@@ -158,9 +212,15 @@ func TestProcessSingleMarker(t *testing.T) {
 		"yaml: exporter marker with absolute indentation, with zero indentation": {
 			callerFile: "./some_file.yaml",
 			marker: &Marker{
-				LineToInsertAt:     5,
-				TargetPath:         "../../testdata/yaml/snippet-with-exporter.yaml",
-				TargetExportMarker: "metadata-only",
+				LineToInsertAt: 5,
+				ImportTargetFile: ImportTargetFile{
+					Type: PathBased,
+					File: "../../testdata/yaml/snippet-with-exporter.yaml",
+				},
+				ImportLogic: ImportLogic{
+					Type:           ExporterMarker,
+					ExporterMarker: "metadata-only",
+				},
 				Indentation: &Indentation{
 					Mode:   AbsoluteIndentation,
 					Length: 0,
@@ -174,9 +234,15 @@ func TestProcessSingleMarker(t *testing.T) {
 		"yaml: exporter marker with extra indentation": {
 			callerFile: "./some_file.yaml",
 			marker: &Marker{
-				LineToInsertAt:     5,
-				TargetPath:         "../../testdata/yaml/snippet-with-exporter.yaml",
-				TargetExportMarker: "sample-nested",
+				LineToInsertAt: 5,
+				ImportTargetFile: ImportTargetFile{
+					Type: PathBased,
+					File: "../../testdata/yaml/snippet-with-exporter.yaml",
+				},
+				ImportLogic: ImportLogic{
+					Type:           ExporterMarker,
+					ExporterMarker: "sample-nested",
+				},
 				Indentation: &Indentation{
 					Mode:   ExtraIndentation,
 					Length: 2,
@@ -194,9 +260,15 @@ func TestProcessSingleMarker(t *testing.T) {
 		"yaml: exporter marker with align indentation": {
 			callerFile: "./some_file.yaml",
 			marker: &Marker{
-				LineToInsertAt:     5,
-				TargetPath:         "../../testdata/yaml/snippet-with-exporter.yaml",
-				TargetExportMarker: "sample-nested",
+				LineToInsertAt: 5,
+				ImportTargetFile: ImportTargetFile{
+					Type: PathBased,
+					File: "../../testdata/yaml/snippet-with-exporter.yaml",
+				},
+				ImportLogic: ImportLogic{
+					Type:           ExporterMarker,
+					ExporterMarker: "sample-nested",
+				},
 				Indentation: &Indentation{
 					Mode:              AlignIndentation,
 					MarkerIndentation: 10,
@@ -215,9 +287,15 @@ func TestProcessSingleMarker(t *testing.T) {
 			callerFile: "./some_unknown_file_type",
 			marker: &Marker{
 				LineToInsertAt: 1, // Not used in this, as single annotation handling is about appending data
-				TargetPath:     "../../testdata/other/note.txt",
-				TargetLineFrom: 1,
-				TargetLineTo:   3,
+				ImportTargetFile: ImportTargetFile{
+					Type: PathBased,
+					File: "../../testdata/other/note.txt",
+				},
+				ImportLogic: ImportLogic{
+					Type:     LineRange,
+					LineFrom: 1,
+					LineTo:   3,
+				},
 			},
 			want: []byte(`This is test data.
 他言語サポートのためのテスト文章。
@@ -228,8 +306,14 @@ func TestProcessSingleMarker(t *testing.T) {
 			callerFile: "./some_unknown_file_type",
 			marker: &Marker{
 				LineToInsertAt: 1,
-				TargetPath:     "../../testdata/other/note.txt",
-				TargetLines:    []int{2, 3},
+				ImportTargetFile: ImportTargetFile{
+					Type: PathBased,
+					File: "../../testdata/other/note.txt",
+				},
+				ImportLogic: ImportLogic{
+					Type:  LineRange,
+					Lines: []int{2, 3},
+				},
 			},
 			want: []byte(`他言語サポートのためのテスト文章。
 🍸 Emojis 🍷 Supported 🍺
@@ -240,30 +324,62 @@ func TestProcessSingleMarker(t *testing.T) {
 		"no target file found": {
 			callerFile: "./some_file.md",
 			marker: &Marker{
-				LineToInsertAt:     1,
-				TargetPath:         "../../does-not-exist.md",
-				TargetExportMarker: "test_exporter",
+				LineToInsertAt: 1,
+				ImportTargetFile: ImportTargetFile{
+					Type: PathBased,
+					File: "../../does-not-exist.md",
+				},
+				ImportLogic: ImportLogic{
+					Type:           ExporterMarker,
+					ExporterMarker: "test_exporter",
+				},
 			},
 			wantErr: os.ErrNotExist,
 		},
-		"no target file information provided": {
+		"no target file information provided - path": {
 			callerFile: "./some_file.md",
 			marker: &Marker{
-				LineToInsertAt:     1,
-				TargetPath:         "", // important
-				TargetURL:          "", // important
-				TargetExportMarker: "test_exporter",
+				LineToInsertAt: 1,
+				ImportTargetFile: ImportTargetFile{
+					Type: PathBased,
+					File: "", // Important
+				},
+				ImportLogic: ImportLogic{
+					Type:           ExporterMarker,
+					ExporterMarker: "test_exporter",
+				},
 			},
 			wantErr: ErrNoFileInput,
+		},
+		"no target file information provided - URL": {
+			callerFile: "./some_file.md",
+			marker: &Marker{
+				LineToInsertAt: 1,
+				ImportTargetFile: ImportTargetFile{
+					Type: URLBased,
+					File: "", // Important
+				},
+				ImportLogic: ImportLogic{
+					Type:           ExporterMarker,
+					ExporterMarker: "test_exporter",
+				},
+			},
+			wantErr: ErrInvalidURL,
 		},
 		"url access error": {
 			callerFile: "./some_file.yaml",
 			marker: &Marker{
 				LineToInsertAt: 5,
-				TargetURL:      "https://some-address-that-does-not-exist",
-				TargetLineFrom: 1,
-				TargetLineTo:   5,
-				Indentation:    nil,
+				ImportTargetFile: ImportTargetFile{
+					Type: URLBased,
+					File: "https://some-address-that-does-not-exist",
+				},
+				ImportLogic: ImportLogic{
+					Type:     LineRange,
+					LineFrom: 1,
+					LineTo:   5,
+				},
+				Indentation: nil,
 			},
 			wantErr: ErrGetMarkerTarget,
 		},
@@ -271,10 +387,16 @@ func TestProcessSingleMarker(t *testing.T) {
 			callerFile: "./some_file.yaml",
 			marker: &Marker{
 				LineToInsertAt: 5,
-				TargetURL:      "https://github.com/does-not-exist.yml#",
-				TargetLineFrom: 1,
-				TargetLineTo:   5,
-				Indentation:    nil,
+				ImportTargetFile: ImportTargetFile{
+					Type: URLBased,
+					File: "https://github.com/does-not-exist.yml#",
+				},
+				ImportLogic: ImportLogic{
+					Type:     LineRange,
+					LineFrom: 1,
+					LineTo:   5,
+				},
+				Indentation: nil,
 			},
 			wantErr: ErrNonSuccessCode,
 		},
@@ -282,10 +404,16 @@ func TestProcessSingleMarker(t *testing.T) {
 			callerFile: "./some_file.yaml",
 			marker: &Marker{
 				LineToInsertAt: 5,
-				TargetURL:      "http///////",
-				TargetLineFrom: 1,
-				TargetLineTo:   5,
-				Indentation:    nil,
+				ImportTargetFile: ImportTargetFile{
+					Type: URLBased,
+					File: "http///////",
+				},
+				ImportLogic: ImportLogic{
+					Type:     LineRange,
+					LineFrom: 1,
+					LineTo:   5,
+				},
+				Indentation: nil,
 			},
 			wantErr: ErrInvalidURL,
 		},

--- a/internal/parse/parse_markdown_test.go
+++ b/internal/parse/parse_markdown_test.go
@@ -35,9 +35,15 @@ func TestParseMarkdown(t *testing.T) {
 					3: {
 						Name:           "lorem",
 						LineToInsertAt: 3,
-						TargetPath:     "./snippet-lorem.md",
-						TargetLineFrom: 5,
-						TargetLineTo:   12,
+						ImportTargetFile: marker.ImportTargetFile{
+							Type: marker.PathBased,
+							File: "./snippet-lorem.md",
+						},
+						ImportLogic: marker.ImportLogic{
+							Type:     marker.LineRange,
+							LineFrom: 5,
+							LineTo:   12,
+						},
 					},
 				},
 			},
@@ -65,9 +71,15 @@ func TestParseMarkdown(t *testing.T) {
 					3: {
 						Name:           "some_importer",
 						LineToInsertAt: 3,
-						TargetPath:     "../../testdata/markdown/simple-before-importer.md",
-						TargetLineFrom: 1,
-						TargetLineTo:   2,
+						ImportTargetFile: marker.ImportTargetFile{
+							Type: marker.PathBased,
+							File: "../../testdata/markdown/simple-before-importer.md",
+						},
+						ImportLogic: marker.ImportLogic{
+							Type:     marker.LineRange,
+							LineFrom: 1,
+							LineTo:   2,
+						},
 					},
 				},
 			},
@@ -84,9 +96,15 @@ func TestParseMarkdown(t *testing.T) {
 					3: {
 						Name:           "some_importer",
 						LineToInsertAt: 3,
-						TargetPath:     "./somefile",
-						TargetLineFrom: 1,
-						TargetLineTo:   2,
+						ImportTargetFile: marker.ImportTargetFile{
+							Type: marker.PathBased,
+							File: "./somefile",
+						},
+						ImportLogic: marker.ImportLogic{
+							Type:     marker.LineRange,
+							LineFrom: 1,
+							LineTo:   2,
+						},
 					},
 				},
 			},

--- a/internal/parse/parse_yaml_test.go
+++ b/internal/parse/parse_yaml_test.go
@@ -32,10 +32,16 @@ func TestParseYAML(t *testing.T) {
 					golden.FileAsString(t, "./testdata/yaml/single-marker-purged.yaml")),
 				Markers: map[int]*marker.Marker{
 					3: {
-						Name:               "some-importer",
-						LineToInsertAt:     3,
-						TargetPath:         "./exporter-example.yaml",
-						TargetExportMarker: "random-data",
+						Name:           "some-importer",
+						LineToInsertAt: 3,
+						ImportTargetFile: marker.ImportTargetFile{
+							Type: marker.PathBased,
+							File: "./exporter-example.yaml",
+						},
+						ImportLogic: marker.ImportLogic{
+							Type:           marker.ExporterMarker,
+							ExporterMarker: "random-data",
+						},
 					},
 				},
 			},
@@ -74,10 +80,16 @@ data:
 `),
 				Markers: map[int]*marker.Marker{
 					3: {
-						Name:               "some_importer",
-						LineToInsertAt:     3,
-						TargetPath:         "./testdata/yaml/exporter-example.yaml",
-						TargetExportMarker: "random-data",
+						Name:           "some_importer",
+						LineToInsertAt: 3,
+						ImportTargetFile: marker.ImportTargetFile{
+							Type: marker.PathBased,
+							File: "./testdata/yaml/exporter-example.yaml",
+						},
+						ImportLogic: marker.ImportLogic{
+							Type:           marker.ExporterMarker,
+							ExporterMarker: "random-data",
+						},
 						Indentation: &marker.Indentation{
 							Mode:              marker.AlignIndentation,
 							MarkerIndentation: 2, // not 6


### PR DESCRIPTION
Refactored

- Instead of using field values to determine the usage pattern, use a separate type alias to find which mode is used for file type (URL or local path), and import logic (line range, comma separated lines, or Exporter Marker)