### PR TITLE
Add importer-skip-update marker

### DIFF
--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -24,6 +24,10 @@ func TestUpdate(t *testing.T) {
 			inputFile: "../../testdata/markdown/import-with-exporter-before.md",
 			wantFile:  "../../testdata/markdown/import-with-exporter-updated.md",
 		},
+		"markdown with skip update": {
+			inputFile: "../../testdata/markdown/skip-update.md",
+			wantFile:  "../../testdata/markdown/skip-update.md",
+		},
 	}
 
 	for name, tc := range cases {

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -23,4 +23,8 @@ type File struct {
 
 	// Markers is an array holding onto each annotation block.
 	Markers map[int]*marker.Marker
+
+	// SkipUpdate is used to skip updating the file in place. This is set by a
+	// special marker syntax.
+	SkipUpdate bool
 }

--- a/internal/file/replace.go
+++ b/internal/file/replace.go
@@ -33,6 +33,13 @@ func (f *File) ReplaceWithAfter(options ...ReplaceOption) error {
 		opt(mode)
 	}
 
+	// If SkipUpdate flag is on, do not update the file.
+	if f.SkipUpdate {
+		// Perhaps it's more friendly to log that the file update is being
+		// skipped. If that's truly the case, handle it here.
+		mode.isDryRun = true
+	}
+
 	return replace(f.FileName, f.ContentAfter, mode)
 }
 

--- a/internal/file/replace_test.go
+++ b/internal/file/replace_test.go
@@ -44,6 +44,18 @@ func TestReplaceWithAfter(t *testing.T) {
 			},
 			want: "", // not written
 		},
+		"skip-update found": {
+			input: &File{
+				FileName: "tmpfile.txt",
+				ContentBefore: []string{
+					"Some data",
+					"and more",
+				},
+				ContentAfter: []byte(`Completely different data`),
+				SkipUpdate:   true,
+			},
+			want: "", // not written
+		},
 	}
 
 	for name, tc := range cases {

--- a/testdata/markdown/skip-update.md
+++ b/testdata/markdown/skip-update.md
@@ -1,0 +1,7 @@
+<!-- == importer-skip-update == -->
+# Markdown Demo
+
+<!-- == imptr: short-description / begin from: ./snippet-description.md#[for-demo] == -->
+This part will not be deleted, because of the "importer-skip-update" marker at the top of the file.
+This is useful for some files that use Importer Markers as "template", and use "importer generate" to generate a separate file.
+<!-- == imptr: short-description / end == -->

--- a/testdata/yaml/skip-update.yaml
+++ b/testdata/yaml/skip-update.yaml
@@ -1,0 +1,6 @@
+# == importer-skip-update ==
+
+title: Demo of YAML Importer
+# == import: description / begin from: ./snippet-description.yaml#[for-demo] ==
+dummy: This data will NOT be removed
+# == import: description / end ==


### PR DESCRIPTION
Fixes #26 

Added

- New marker `importer-skip-update` to skip updating the file in place. This flag does not interfere with `importer generate`.