### PR TITLE
Update indentation logic to support non-whitespace characters

### DIFF
--- a/internal/marker/marker.go
+++ b/internal/marker/marker.go
@@ -139,7 +139,7 @@ func processIndentOption(marker *Marker, match *RawMarker) error {
 		case "extra":
 			marker.Indentation = &Indentation{Mode: ExtraIndentation}
 		case "align":
-			markerIndentation := len(match.PrecedingIndentation) - len(strings.TrimLeft(match.PrecedingIndentation, " ")) // Naïve count
+			markerIndentation := len(match.PrecedingIndentation)
 			marker.Indentation = &Indentation{
 				Mode:              AlignIndentation,
 				MarkerIndentation: markerIndentation,

--- a/internal/marker/marker_regex.go
+++ b/internal/marker/marker_regex.go
@@ -10,7 +10,7 @@ var (
 	ImporterMarkerMarkdown = `<!-- == (imptr|import|importer|i): (?P<importer_name>\S+) \/ (?P<importer_marker>begin|end)(?P<importer_option>.*) == -->`
 
 	// ImporterMarkerYAML is the annotation used for importer to find match.
-	ImporterMarkerYAML = `(?P<importer_marker_indentation>\s*)# == (imptr|import|importer|i): (?P<importer_name>\S+) \/ (?P<importer_marker>begin|end)(?P<importer_option>.*) ==`
+	ImporterMarkerYAML = `(?P<importer_marker_indentation>.*)# == (imptr|import|importer|i): (?P<importer_name>\S+) \/ (?P<importer_marker>begin|end)(?P<importer_option>.*) ==`
 
 	// OptionFilePathIndicator is the pattern used for parsing Importer file options.
 	OptionFilePathIndicator = `from: (?P<importer_target_path>\S+)\s*\#(?P<importer_target_detail>[0-9a-zA-Z,-_\~]+)\s?`

--- a/internal/marker/marker_test.go
+++ b/internal/marker/marker_test.go
@@ -159,7 +159,7 @@ func TestNewMarker(t *testing.T) {
 				IsEndFound:           true,
 				LineToInsertAt:       3,
 				Options:              "from: ./abc.yaml#[from-exporter-marker] indent: align",
-				PrecedingIndentation: "    ",
+				PrecedingIndentation: "  - ", // As if yaml list input is used for indentation
 			},
 			want: &marker.Marker{
 				Name:           "simple-marker",

--- a/testdata/yaml/align-with-exporter-before.yaml
+++ b/testdata/yaml/align-with-exporter-before.yaml
@@ -7,11 +7,11 @@ data:
     indentation:
       for:
         demo:
-          # == importer: abc-tree / begin from: ./snippet-with-exporter.yaml#[long-tree] indent: align ==
-          anything: here
-          would: be
-          purged: by Importer
-          # == importer: abc-tree / end ==
+          - # == importer: abc-tree / begin from: ./snippet-with-exporter.yaml#[long-tree] indent: align ==
+            anything: here
+            would: be
+            purged: by Importer
+            # == importer: abc-tree / end ==
 
   some-data:
     description: |

--- a/testdata/yaml/align-with-exporter-purged.yaml
+++ b/testdata/yaml/align-with-exporter-purged.yaml
@@ -7,8 +7,8 @@ data:
     indentation:
       for:
         demo:
-          # == importer: abc-tree / begin from: ./snippet-with-exporter.yaml#[long-tree] indent: align ==
-          # == importer: abc-tree / end ==
+          - # == importer: abc-tree / begin from: ./snippet-with-exporter.yaml#[long-tree] indent: align ==
+            # == importer: abc-tree / end ==
 
   some-data:
     description: |

--- a/testdata/yaml/align-with-exporter-updated.yaml
+++ b/testdata/yaml/align-with-exporter-updated.yaml
@@ -7,19 +7,19 @@ data:
     indentation:
       for:
         demo:
-          # == importer: abc-tree / begin from: ./snippet-with-exporter.yaml#[long-tree] indent: align ==
-          a:
-            b:
-              c:
-                d:
-                  e:
-                    f:
-                      g:
-                        h:
-                          i:
-                            j:
-                              k: {}
-          # == importer: abc-tree / end ==
+          - # == importer: abc-tree / begin from: ./snippet-with-exporter.yaml#[long-tree] indent: align ==
+            a:
+              b:
+                c:
+                  d:
+                    e:
+                      f:
+                        g:
+                          h:
+                            i:
+                              j:
+                                k: {}
+            # == importer: abc-tree / end ==
 
   some-data:
     description: |


### PR DESCRIPTION
Fixes #58 

Updated

- Indentation handling logic using `indent: align` now respects any preceding characters before the Importer Marker