### PR TITLE
Fix incorrect marker removal

### DIFF
--- a/internal/file/process_test.go
+++ b/internal/file/process_test.go
@@ -186,6 +186,46 @@ a:
     c: data
 `),
 		},
+		"yaml: importer marker is removed but the rest of the line is kept": {
+			file: &File{
+				FileName: "test-file.yaml",
+				ContentAfter: []byte(`
+data:
+  - # == i: abc / begin from: some-file.yaml#[abc] ==
+    a:
+      b:
+        c: data
+    # == i: abc / end ==
+`),
+			},
+			want: []byte(`
+data:
+  - 
+    a:
+      b:
+        c: data
+`),
+		},
+		"yaml: exporter marker is removed but the rest of the line is kept": {
+			file: &File{
+				FileName: "test-file.yaml",
+				ContentAfter: []byte(`
+data:
+  - # == e: abc / begin ==
+    a:
+      b:
+        c: data
+    # == i: abc / end ==
+`),
+			},
+			want: []byte(`
+data:
+  - 
+    a:
+      b:
+        c: data
+`),
+		},
 		"unknown file type: keep input as is": {
 			file: &File{
 				FileName: "test-file.dummy",
@@ -214,7 +254,7 @@ a:
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			tc.file.RemoveMarkers()
-			if diff := cmp.Diff(tc.want, tc.file.ContentAfter); diff != "" {
+			if diff := cmp.Diff(string(tc.want), string(tc.file.ContentAfter)); diff != "" {
 				t.Errorf("parsed result didn't match (-want / +got)\n%s", diff)
 			}
 		})

--- a/internal/marker/marker_regex.go
+++ b/internal/marker/marker_regex.go
@@ -44,5 +44,5 @@ var (
 	//     # == export: random_data / begin ==
 	//     random-data: this is exported
 	//     # == export: random_data / end ==
-	ExporterMarkerYAML = `(?P<export_marker_indent>\s*)# == (exptr|export|exporter|e): (?P<export_marker_name>\S+) \/ (?P<exporter_marker_condition>begin|end) ==`
+	ExporterMarkerYAML = `(?P<export_marker_indent>.*)# == (exptr|export|exporter|e): (?P<export_marker_name>\S+) \/ (?P<exporter_marker_condition>begin|end) ==`
 )

--- a/internal/regexpplus/map.go
+++ b/internal/regexpplus/map.go
@@ -21,6 +21,19 @@ var (
 // create a map that will not have all the matched components.
 func MapWithNamedSubgroups(targetLine string, expression string) (map[string]string, error) {
 	re := regexp.MustCompile(expression)
+	return MapWithNamedSubgroupsRegexp(targetLine, re)
+}
+
+// MapWithNamedSubgroupsRegexp runs regexp FindStringSubmatch against
+// `targetLine` input, and returns a map representation. The map contains the
+// key as the subgroup name, and value for the matched data.
+//
+// If there is no match found, an error of ErrNoMatch will be returned.
+//
+// This can be used for regular expression which does not have any subgroup,
+// but as it is designed specifically for subgroup based use cases, it will
+// create a map that will not have all the matched components.
+func MapWithNamedSubgroupsRegexp(targetLine string, re *regexp.Regexp) (map[string]string, error) {
 	ms := re.FindStringSubmatch(targetLine)
 
 	if len(ms) == 0 {


### PR DESCRIPTION
Fixes #63 

Fixed

- Marker removal logic now only removes the marker data, and remove the target line if the line only has whitespace characters other than the marker. If there are some other content in the same line, those will be kept.