### PR TITLE
Fix space only line

### DIFF
--- a/internal/marker/indent.go
+++ b/internal/marker/indent.go
@@ -77,6 +77,10 @@ func handleAbsoluteIndentation(lineData []byte, exportMarkerIndent, targetIndent
 }
 
 func prependWhitespaces(x []byte, count int) []byte {
+	// If provided line only has space chars, return the line data as is.
+	if len(bytes.TrimSpace(x)) == 0 {
+		return x
+	}
 	empty := bytes.Repeat([]byte(" "), count)
 	// x = append(x, empty...)
 	// copy(x[count:], x)

--- a/internal/marker/indent_test.go
+++ b/internal/marker/indent_test.go
@@ -55,6 +55,11 @@ func TestPrependWhitespaces(t *testing.T) {
 			whitespaceCount: 6,
 			want:            []byte("        abcdef"),
 		},
+		"line with only whitespace": {
+			originalSlice:   []byte("    "),
+			whitespaceCount: 6,
+			want:            []byte("    "), // No change
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/testdata/markdown/verbatim-yaml-updated.md
+++ b/testdata/markdown/verbatim-yaml-updated.md
@@ -6,6 +6,7 @@
     requests:
       cpu: 10m
       memory: 10Mi
+
     limits:
       cpu: 30m
       memory: 30Mi

--- a/testdata/markdown/verbatim-yaml-wrap-updated.md
+++ b/testdata/markdown/verbatim-yaml-wrap-updated.md
@@ -6,6 +6,7 @@
     requests:
       cpu: 10m
       memory: 10Mi
+
     limits:
       cpu: 30m
       memory: 30Mi

--- a/testdata/yaml/k8s-color-svc-updated.yaml
+++ b/testdata/yaml/k8s-color-svc-updated.yaml
@@ -63,6 +63,7 @@ spec:
             requests:
               cpu: 10m
               memory: 10Mi
+
             limits:
               cpu: 30m
               memory: 30Mi

--- a/testdata/yaml/snippet-k8s-resource.yaml
+++ b/testdata/yaml/snippet-k8s-resource.yaml
@@ -4,6 +4,7 @@ minimal:
     requests:
       cpu: 10m
       memory: 10Mi
+
     limits:
       cpu: 30m
       memory: 30Mi


### PR DESCRIPTION
Fixes #80 

- When the line only contains whitespace characters, do not process any more. This does not remove any existing spaces, as that should be linter / formatter to handle.